### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/127/699/288/7/1276992887.geojson
+++ b/data/127/699/288/7/1276992887.geojson
@@ -51,6 +51,9 @@
         "gn:id":3612283
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "geonames"
+    ],
     "wof:geomhash":"a6506f660402773269151d3ab415a8ec",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":1276992887,
-    "wof:lastmodified":1573586664,
+    "wof:lastmodified":1582319244,
     "wof:name":"El Cayo Sierra",
     "wof:parent_id":421182985,
     "wof:placetype":"locality",

--- a/data/421/169/617/421169617.geojson
+++ b/data/421/169/617/421169617.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008817,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c21a91cf7cd282197ccf44a9f7372ee",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421169617,
-    "wof:lastmodified":1566645804,
+    "wof:lastmodified":1582319270,
     "wof:name":"Belen Gualcho",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/169/619/421169619.geojson
+++ b/data/421/169/619/421169619.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008817,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"75681495886c1c50a8900e358a4a3228",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421169619,
-    "wof:lastmodified":1566645806,
+    "wof:lastmodified":1582319270,
     "wof:name":"Bonito Oriental",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/169/621/421169621.geojson
+++ b/data/421/169/621/421169621.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008817,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0267435a353f0336c690f38f02455484",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421169621,
-    "wof:lastmodified":1566645805,
+    "wof:lastmodified":1582319270,
     "wof:name":"Sinuapa",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/170/691/421170691.geojson
+++ b/data/421/170/691/421170691.geojson
@@ -132,6 +132,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008864,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb5744c5c60b48d77737106f7c152abf",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":421170691,
-    "wof:lastmodified":1566645976,
+    "wof:lastmodified":1582319358,
     "wof:name":"Catacamas",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/170/693/421170693.geojson
+++ b/data/421/170/693/421170693.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008864,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7119ffb1372c7de169d6afb086e2e15c",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421170693,
-    "wof:lastmodified":1566645966,
+    "wof:lastmodified":1582319353,
     "wof:name":"Esparta",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/170/695/421170695.geojson
+++ b/data/421/170/695/421170695.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008864,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a35025dfcda6bb126fd1f988a449615",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421170695,
-    "wof:lastmodified":1566645968,
+    "wof:lastmodified":1582319354,
     "wof:name":"El Porvenir",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/170/697/421170697.geojson
+++ b/data/421/170/697/421170697.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008864,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ed53347ac8c42176c75fee7ea40db6c",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421170697,
-    "wof:lastmodified":1566645975,
+    "wof:lastmodified":1582319357,
     "wof:name":"Iriona",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/170/699/421170699.geojson
+++ b/data/421/170/699/421170699.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008864,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"419f6042e5f110410533bb6f64c98b80",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421170699,
-    "wof:lastmodified":1566645973,
+    "wof:lastmodified":1582319356,
     "wof:name":"Intibuca",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/170/703/421170703.geojson
+++ b/data/421/170/703/421170703.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008865,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f3b5b6b449fe64743586f27dc1262a07",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421170703,
-    "wof:lastmodified":1566645971,
+    "wof:lastmodified":1582319355,
     "wof:name":"Jose Santos Guardiola",
     "wof:parent_id":85671869,
     "wof:placetype":"county",

--- a/data/421/170/707/421170707.geojson
+++ b/data/421/170/707/421170707.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008865,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47aae7155ff254381722237567ea6f44",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421170707,
-    "wof:lastmodified":1566645965,
+    "wof:lastmodified":1582319352,
     "wof:name":"Lepaterique",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/170/709/421170709.geojson
+++ b/data/421/170/709/421170709.geojson
@@ -225,6 +225,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008865,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9920099a2ad5fd6c56693da20ce67408",
     "wof:hierarchy":[
         {
@@ -235,7 +238,7 @@
         }
     ],
     "wof:id":421170709,
-    "wof:lastmodified":1566645963,
+    "wof:lastmodified":1582319351,
     "wof:name":"San Pedro Sula",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/170/711/421170711.geojson
+++ b/data/421/170/711/421170711.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008865,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69bed78ab67f8cb354646fd9b7043faf",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421170711,
-    "wof:lastmodified":1566645981,
+    "wof:lastmodified":1582319360,
     "wof:name":"Santa Cruz de Yojoa",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/170/947/421170947.geojson
+++ b/data/421/170/947/421170947.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008875,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2fe7df46c053198f905ad38aca723405",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421170947,
-    "wof:lastmodified":1566645970,
+    "wof:lastmodified":1582319354,
     "wof:name":"Santa Lucia",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/170/949/421170949.geojson
+++ b/data/421/170/949/421170949.geojson
@@ -212,6 +212,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008875,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9486e3f789b4c1f40cd9034b5693d83c",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":421170949,
-    "wof:lastmodified":1566645970,
+    "wof:lastmodified":1582319354,
     "wof:name":"Santa Barbara",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/172/257/421172257.geojson
+++ b/data/421/172/257/421172257.geojson
@@ -171,6 +171,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008929,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8ea1f85feecaf40defa0194b8034e733",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":421172257,
-    "wof:lastmodified":1566645877,
+    "wof:lastmodified":1582319307,
     "wof:name":"Santa Ana",
     "wof:parent_id":421184595,
     "wof:placetype":"locality",

--- a/data/421/172/427/421172427.geojson
+++ b/data/421/172/427/421172427.geojson
@@ -183,6 +183,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008940,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"915e1080cbb57c667a7c6c79650ea67f",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         }
     ],
     "wof:id":421172427,
-    "wof:lastmodified":1566645880,
+    "wof:lastmodified":1582319308,
     "wof:name":"La Ceiba",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/172/429/421172429.geojson
+++ b/data/421/172/429/421172429.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008940,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"629039a9e23b0fde67a5b91d3e1db820",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421172429,
-    "wof:lastmodified":1566645879,
+    "wof:lastmodified":1582319308,
     "wof:name":"Omoa",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/172/431/421172431.geojson
+++ b/data/421/172/431/421172431.geojson
@@ -157,6 +157,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008941,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"240fc5c1f936d99bedc0bee4f38037e1",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":421172431,
-    "wof:lastmodified":1566645878,
+    "wof:lastmodified":1582319307,
     "wof:name":"Roatan",
     "wof:parent_id":85671869,
     "wof:placetype":"county",

--- a/data/421/172/435/421172435.geojson
+++ b/data/421/172/435/421172435.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008942,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d85e5e3e95ce60b41b0dc84153c7d77",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421172435,
-    "wof:lastmodified":1566645882,
+    "wof:lastmodified":1582319309,
     "wof:name":"Tela",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/172/467/421172467.geojson
+++ b/data/421/172/467/421172467.geojson
@@ -194,6 +194,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008943,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"83e66af61b98bf04a0d4f2554717ed01",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
         }
     ],
     "wof:id":421172467,
-    "wof:lastmodified":1566645881,
+    "wof:lastmodified":1582319309,
     "wof:name":"Talanga",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/173/057/421173057.geojson
+++ b/data/421/173/057/421173057.geojson
@@ -562,6 +562,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459008969,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e1e2d3248a9b1bfc39cccadfd03d76d",
     "wof:hierarchy":[
         {
@@ -573,7 +576,7 @@
         }
     ],
     "wof:id":421173057,
-    "wof:lastmodified":1566645840,
+    "wof:lastmodified":1582319285,
     "wof:name":"Tegucigalpa",
     "wof:parent_id":1108701727,
     "wof:placetype":"locality",

--- a/data/421/175/543/421175543.geojson
+++ b/data/421/175/543/421175543.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009071,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81d45ed816c4fe97c03e5fe98ce283b3",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421175543,
-    "wof:lastmodified":1566645906,
+    "wof:lastmodified":1582319324,
     "wof:name":"San Sebastian",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/176/121/421176121.geojson
+++ b/data/421/176/121/421176121.geojson
@@ -242,7 +242,8 @@
     "qs:woe_id":101942,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "wd:elevation":800.0,
     "wd:latitude":14.583333,
@@ -264,6 +265,10 @@
     },
     "wof:country":"HN",
     "wof:created":1459009096,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"ff0ed3644dee33468c6d4513b7a009d1",
     "wof:hierarchy":[
         {
@@ -275,7 +280,7 @@
         }
     ],
     "wof:id":421176121,
-    "wof:lastmodified":1561749479,
+    "wof:lastmodified":1582319392,
     "wof:name":"Gracias",
     "wof:parent_id":421188757,
     "wof:placetype":"locality",

--- a/data/421/176/279/421176279.geojson
+++ b/data/421/176/279/421176279.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009103,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"16592af0ab607e10862b719f216af99d",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":421176279,
-    "wof:lastmodified":1566646049,
+    "wof:lastmodified":1582319392,
     "wof:name":"El Corpus",
     "wof:parent_id":421185037,
     "wof:placetype":"locality",

--- a/data/421/176/281/421176281.geojson
+++ b/data/421/176/281/421176281.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009103,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1125b2e061ca897a2c09a558dd337c5d",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":421176281,
-    "wof:lastmodified":1566646048,
+    "wof:lastmodified":1582319391,
     "wof:name":"Cofrad\u00eda",
     "wof:parent_id":421170709,
     "wof:placetype":"locality",

--- a/data/421/177/087/421177087.geojson
+++ b/data/421/177/087/421177087.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009132,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db3937fc200933cd2171002fff98fe9c",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421177087,
-    "wof:lastmodified":1566645984,
+    "wof:lastmodified":1582319361,
     "wof:name":"Wampusirpi",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/421/177/939/421177939.geojson
+++ b/data/421/177/939/421177939.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009165,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"028583d200c4c9a521357d7640adcbcd",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421177939,
-    "wof:lastmodified":1566645982,
+    "wof:lastmodified":1582319361,
     "wof:name":"El Nispero",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/177/943/421177943.geojson
+++ b/data/421/177/943/421177943.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009165,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d41e57fbf2b6420b036c8fd052e78f7",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421177943,
-    "wof:lastmodified":1566645985,
+    "wof:lastmodified":1582319361,
     "wof:name":"San Marcos de Colon",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/179/727/421179727.geojson
+++ b/data/421/179/727/421179727.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009231,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7837c304fb900af2cdf69428114d2eaf",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":421179727,
-    "wof:lastmodified":1566646002,
+    "wof:lastmodified":1582319367,
     "wof:name":"San Miguel Guancapia",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/179/809/421179809.geojson
+++ b/data/421/179/809/421179809.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009233,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f392348aa5f23ddb2bd419d59f93779",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421179809,
-    "wof:lastmodified":1566646000,
+    "wof:lastmodified":1582319367,
     "wof:name":"Taulabe",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/181/053/421181053.geojson
+++ b/data/421/181/053/421181053.geojson
@@ -99,6 +99,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009283,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"537df66fada2bc3f2fc93819df5b9fe4",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421181053,
-    "wof:lastmodified":1566645887,
+    "wof:lastmodified":1582319312,
     "wof:name":"El Porvenir",
     "wof:parent_id":421170695,
     "wof:placetype":"locality",

--- a/data/421/181/669/421181669.geojson
+++ b/data/421/181/669/421181669.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009303,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf2af6b9a89155d21ec65f1cb0fe73b6",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421181669,
-    "wof:lastmodified":1566645887,
+    "wof:lastmodified":1582319313,
     "wof:name":"Yamaranguila",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/181/805/421181805.geojson
+++ b/data/421/181/805/421181805.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009307,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f00144569bd21dcc60b2c0356bf82a48",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421181805,
-    "wof:lastmodified":1566645888,
+    "wof:lastmodified":1582319313,
     "wof:name":"Meambar",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/181/807/421181807.geojson
+++ b/data/421/181/807/421181807.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009307,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1111ad8ee82d6892247a9da83aa2ecd5",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421181807,
-    "wof:lastmodified":1566645891,
+    "wof:lastmodified":1582319314,
     "wof:name":"Nacaome",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/181/809/421181809.geojson
+++ b/data/421/181/809/421181809.geojson
@@ -147,6 +147,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009307,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"42c35cccf766975adfcf5e64790c113c",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":421181809,
-    "wof:lastmodified":1566645895,
+    "wof:lastmodified":1582319318,
     "wof:name":"Puerto Lempira",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/421/181/917/421181917.geojson
+++ b/data/421/181/917/421181917.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009312,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5748db080e27833c41ba1264c2aef88d",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421181917,
-    "wof:lastmodified":1566645905,
+    "wof:lastmodified":1582319324,
     "wof:name":"Talgua",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/181/921/421181921.geojson
+++ b/data/421/181/921/421181921.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009312,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3527d2a482d671d719aafaa09e7bbc2d",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421181921,
-    "wof:lastmodified":1566645904,
+    "wof:lastmodified":1582319323,
     "wof:name":"Arenal",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/181/923/421181923.geojson
+++ b/data/421/181/923/421181923.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009312,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db44cc2791628f6e90ffe293768639aa",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421181923,
-    "wof:lastmodified":1566645889,
+    "wof:lastmodified":1582319313,
     "wof:name":"Morolica",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/181/925/421181925.geojson
+++ b/data/421/181/925/421181925.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009312,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"20063373d3ff6a0cb99342630c3c85ed",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421181925,
-    "wof:lastmodified":1566645890,
+    "wof:lastmodified":1582319314,
     "wof:name":"Nueva Armenia",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/182/069/421182069.geojson
+++ b/data/421/182/069/421182069.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009317,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38a095d2c4238300b24e429d8d483212",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421182069,
-    "wof:lastmodified":1566646040,
+    "wof:lastmodified":1582319387,
     "wof:name":"San Lucas",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/173/421182173.geojson
+++ b/data/421/182/173/421182173.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009321,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e05d5378d96f0b627b398a8a0faa69d3",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421182173,
-    "wof:lastmodified":1566646016,
+    "wof:lastmodified":1582319375,
     "wof:name":"San Esteban",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/182/565/421182565.geojson
+++ b/data/421/182/565/421182565.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009334,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db84abc594a033cf356991f2f3782f7a",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421182565,
-    "wof:lastmodified":1566646038,
+    "wof:lastmodified":1582319386,
     "wof:name":"Arada",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/182/569/421182569.geojson
+++ b/data/421/182/569/421182569.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009334,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4c8dd516b2fd87a583f912a8d20acb39",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421182569,
-    "wof:lastmodified":1566646004,
+    "wof:lastmodified":1582319369,
     "wof:name":"Aramecina",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/182/573/421182573.geojson
+++ b/data/421/182/573/421182573.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009334,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82bb2a2448c416225f8265f8439dce46",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421182573,
-    "wof:lastmodified":1566646030,
+    "wof:lastmodified":1582319382,
     "wof:name":"Colomoncagua",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/182/575/421182575.geojson
+++ b/data/421/182/575/421182575.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009334,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9407930bddb3f86a754a5d8b8a186db",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421182575,
-    "wof:lastmodified":1566646020,
+    "wof:lastmodified":1582319377,
     "wof:name":"El Paraiso",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/182/579/421182579.geojson
+++ b/data/421/182/579/421182579.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009334,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2490770b45ab279bec7a24041c35daee",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421182579,
-    "wof:lastmodified":1566646044,
+    "wof:lastmodified":1582319390,
     "wof:name":"La Virtud",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/581/421182581.geojson
+++ b/data/421/182/581/421182581.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009335,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c7e7de558510be2a9cf34efbaa37fdfa",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182581,
-    "wof:lastmodified":1566646020,
+    "wof:lastmodified":1582319377,
     "wof:name":"Lamani",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/182/583/421182583.geojson
+++ b/data/421/182/583/421182583.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009335,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c797c1ded64a41dde68000b90806c74b",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182583,
-    "wof:lastmodified":1566646046,
+    "wof:lastmodified":1582319391,
     "wof:name":"Langue",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/182/587/421182587.geojson
+++ b/data/421/182/587/421182587.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009335,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee89bfcfc3618173865b900ef477f0f4",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421182587,
-    "wof:lastmodified":1566646029,
+    "wof:lastmodified":1582319381,
     "wof:name":"Las Flores",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/589/421182589.geojson
+++ b/data/421/182/589/421182589.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009335,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b26b17f987888acfb031d5f475bd71d",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421182589,
-    "wof:lastmodified":1566646027,
+    "wof:lastmodified":1582319380,
     "wof:name":"San Fernando",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/182/591/421182591.geojson
+++ b/data/421/182/591/421182591.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009335,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1556a69f51c62bf43610db77e300a07",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421182591,
-    "wof:lastmodified":1566646039,
+    "wof:lastmodified":1582319387,
     "wof:name":"San Francisco de Coray",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/182/887/421182887.geojson
+++ b/data/421/182/887/421182887.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a0a5251fb32d1d4280956c0f085f1fc",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421182887,
-    "wof:lastmodified":1566646013,
+    "wof:lastmodified":1582319373,
     "wof:name":"Aguanqueterique",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/182/889/421182889.geojson
+++ b/data/421/182/889/421182889.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57204dd2b00ba1c8ecd73248486deeb7",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421182889,
-    "wof:lastmodified":1566646010,
+    "wof:lastmodified":1582319372,
     "wof:name":"Brus Laguna",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/421/182/893/421182893.geojson
+++ b/data/421/182/893/421182893.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9e696bfcab4c1a86e06b0c580d1fac88",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421182893,
-    "wof:lastmodified":1566646014,
+    "wof:lastmodified":1582319374,
     "wof:name":"Candelaria",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/895/421182895.geojson
+++ b/data/421/182/895/421182895.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69dbd642cb8d9d8a9669ecbb78767d25",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421182895,
-    "wof:lastmodified":1566646013,
+    "wof:lastmodified":1582319373,
     "wof:name":"Cacuyagua",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/182/897/421182897.geojson
+++ b/data/421/182/897/421182897.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"14d3f6e5904fc7fc9e46a0b24c8f7262",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421182897,
-    "wof:lastmodified":1566646041,
+    "wof:lastmodified":1582319387,
     "wof:name":"Dolores Merendon",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/182/901/421182901.geojson
+++ b/data/421/182/901/421182901.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"764d930dd4473257c3b298a856be6dd1",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":421182901,
-    "wof:lastmodified":1566646007,
+    "wof:lastmodified":1582319370,
     "wof:name":"Dolores",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/182/903/421182903.geojson
+++ b/data/421/182/903/421182903.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a0c28ec5a5e2af75590a2506d5d94fc",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182903,
-    "wof:lastmodified":1566646034,
+    "wof:lastmodified":1582319384,
     "wof:name":"Duyure",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/182/905/421182905.geojson
+++ b/data/421/182/905/421182905.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd9f30307e35738c8ca2fefe792e6034",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421182905,
-    "wof:lastmodified":1566646037,
+    "wof:lastmodified":1582319386,
     "wof:name":"El Rosario",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/182/907/421182907.geojson
+++ b/data/421/182/907/421182907.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66af70012af0e5dc134342a2d55dc93b",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421182907,
-    "wof:lastmodified":1566646004,
+    "wof:lastmodified":1582319369,
     "wof:name":"El Triunfo",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/182/911/421182911.geojson
+++ b/data/421/182/911/421182911.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009351,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b026a7d970795554028b3c5a60dfcb47",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182911,
-    "wof:lastmodified":1566646041,
+    "wof:lastmodified":1582319388,
     "wof:name":"Erandique",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/913/421182913.geojson
+++ b/data/421/182/913/421182913.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91f8ccef4134d972c36052f40d8283ca",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182913,
-    "wof:lastmodified":1566646028,
+    "wof:lastmodified":1582319381,
     "wof:name":"Esquipulas del Norte",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/182/915/421182915.geojson
+++ b/data/421/182/915/421182915.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cbd5bd766fc9576536ff7ab717d75cb0",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421182915,
-    "wof:lastmodified":1566646019,
+    "wof:lastmodified":1582319376,
     "wof:name":"Guinope",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/917/421182917.geojson
+++ b/data/421/182/917/421182917.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4d32b336a9aa46bcafd3acf81545774b",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421182917,
-    "wof:lastmodified":1566646046,
+    "wof:lastmodified":1582319391,
     "wof:name":"Ilama",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/182/919/421182919.geojson
+++ b/data/421/182/919/421182919.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ff14ac087ccd4e22b7d164e809656178",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182919,
-    "wof:lastmodified":1566646044,
+    "wof:lastmodified":1582319389,
     "wof:name":"Jacaleapa",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/921/421182921.geojson
+++ b/data/421/182/921/421182921.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"caba43facd348e1ab27adc3ce168fc6e",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421182921,
-    "wof:lastmodified":1566646045,
+    "wof:lastmodified":1582319390,
     "wof:name":"Jesus de Otoro",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/182/923/421182923.geojson
+++ b/data/421/182/923/421182923.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ea139c8020e5ed983b8df6462a347c76",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421182923,
-    "wof:lastmodified":1566646021,
+    "wof:lastmodified":1582319377,
     "wof:name":"La Campa",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/925/421182925.geojson
+++ b/data/421/182/925/421182925.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91223b73388f1bd9a21d3164840a9545",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421182925,
-    "wof:lastmodified":1566646026,
+    "wof:lastmodified":1582319380,
     "wof:name":"La Libertad",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/182/929/421182929.geojson
+++ b/data/421/182/929/421182929.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b8ee4fef540dc82e53d69c4b1ec1dd6",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421182929,
-    "wof:lastmodified":1566646042,
+    "wof:lastmodified":1582319388,
     "wof:name":"La Masica",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/182/931/421182931.geojson
+++ b/data/421/182/931/421182931.geojson
@@ -194,6 +194,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"013a4908a54c6726c4cbab212bd8e3b7",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
         }
     ],
     "wof:id":421182931,
-    "wof:lastmodified":1566646003,
+    "wof:lastmodified":1582319368,
     "wof:name":"La Union",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/933/421182933.geojson
+++ b/data/421/182/933/421182933.geojson
@@ -194,6 +194,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eff23ded21d9c857e24f0a2cb47a857d",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
         }
     ],
     "wof:id":421182933,
-    "wof:lastmodified":1566646039,
+    "wof:lastmodified":1582319387,
     "wof:name":"La Union",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/182/935/421182935.geojson
+++ b/data/421/182/935/421182935.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"387bad1df3671066981223faac1a00cc",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421182935,
-    "wof:lastmodified":1566646033,
+    "wof:lastmodified":1582319383,
     "wof:name":"La Venta",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/182/937/421182937.geojson
+++ b/data/421/182/937/421182937.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3be0788e62db658962bb593d0061965f",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421182937,
-    "wof:lastmodified":1566646009,
+    "wof:lastmodified":1582319371,
     "wof:name":"Macuelizo",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/182/939/421182939.geojson
+++ b/data/421/182/939/421182939.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009352,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c463403ea3fb08bd10ca0ab8203c0fb0",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421182939,
-    "wof:lastmodified":1566646008,
+    "wof:lastmodified":1582319370,
     "wof:name":"Manto",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/182/941/421182941.geojson
+++ b/data/421/182/941/421182941.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ec570a8eddeab479ff1ece9407104a7",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421182941,
-    "wof:lastmodified":1566646018,
+    "wof:lastmodified":1582319376,
     "wof:name":"Mapulaca",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/943/421182943.geojson
+++ b/data/421/182/943/421182943.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f01359dcd8c82c599688c95350a2752",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182943,
-    "wof:lastmodified":1566646047,
+    "wof:lastmodified":1582319391,
     "wof:name":"Maraita",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/182/947/421182947.geojson
+++ b/data/421/182/947/421182947.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e301596ed70ebd2ef13a6c7d8dcf78a",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182947,
-    "wof:lastmodified":1566646022,
+    "wof:lastmodified":1582319378,
     "wof:name":"Opatoro",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/182/949/421182949.geojson
+++ b/data/421/182/949/421182949.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78adc43668dd024234e418616439a70c",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421182949,
-    "wof:lastmodified":1566646026,
+    "wof:lastmodified":1582319379,
     "wof:name":"Oropoli",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/951/421182951.geojson
+++ b/data/421/182/951/421182951.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a52a3d56b1edc896bff1ab934d05484",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182951,
-    "wof:lastmodified":1566646037,
+    "wof:lastmodified":1582319385,
     "wof:name":"Pespire",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/182/953/421182953.geojson
+++ b/data/421/182/953/421182953.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7fa66cb5ea69b28350996c830e9010b",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421182953,
-    "wof:lastmodified":1566646006,
+    "wof:lastmodified":1582319369,
     "wof:name":"Petoa",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/182/957/421182957.geojson
+++ b/data/421/182/957/421182957.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"728b0d6798ce25a2d552939c769b799e",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421182957,
-    "wof:lastmodified":1566646031,
+    "wof:lastmodified":1582319382,
     "wof:name":"Sabanagrande",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/182/959/421182959.geojson
+++ b/data/421/182/959/421182959.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d88c21a3e7d1d5ecd6dbd71a472187a5",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421182959,
-    "wof:lastmodified":1566646032,
+    "wof:lastmodified":1582319383,
     "wof:name":"Salama",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/182/961/421182961.geojson
+++ b/data/421/182/961/421182961.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5339a09ad0c50077d787f36afbe9c703",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421182961,
-    "wof:lastmodified":1566646032,
+    "wof:lastmodified":1582319383,
     "wof:name":"San Manuel",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/182/965/421182965.geojson
+++ b/data/421/182/965/421182965.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f964b992f5d80e2d804503ce215e32e8",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421182965,
-    "wof:lastmodified":1566646006,
+    "wof:lastmodified":1582319370,
     "wof:name":"San Marcos",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/182/967/421182967.geojson
+++ b/data/421/182/967/421182967.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7475ba4a662303a722d1c848cb105b62",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421182967,
-    "wof:lastmodified":1566646034,
+    "wof:lastmodified":1582319384,
     "wof:name":"Santa Ana",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/182/969/421182969.geojson
+++ b/data/421/182/969/421182969.geojson
@@ -228,6 +228,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ef23aba51e9680dc9e83ca9fc804dcbb",
     "wof:hierarchy":[
         {
@@ -238,7 +241,7 @@
         }
     ],
     "wof:id":421182969,
-    "wof:lastmodified":1566646036,
+    "wof:lastmodified":1582319385,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/971/421182971.geojson
+++ b/data/421/182/971/421182971.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009353,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d94a3def2e39337387f41bcf4a2467b",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":421182971,
-    "wof:lastmodified":1566646024,
+    "wof:lastmodified":1582319378,
     "wof:name":"Santa Rita",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/182/973/421182973.geojson
+++ b/data/421/182/973/421182973.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009354,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad768248474f397d57cba55ce47c7d7a",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421182973,
-    "wof:lastmodified":1566646043,
+    "wof:lastmodified":1582319389,
     "wof:name":"Sta. Rosa de Aguan",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/182/975/421182975.geojson
+++ b/data/421/182/975/421182975.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009354,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"744258539bd1400111dba45cb016bc06",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421182975,
-    "wof:lastmodified":1566646047,
+    "wof:lastmodified":1582319391,
     "wof:name":"Santiago de Puringla",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/182/977/421182977.geojson
+++ b/data/421/182/977/421182977.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009354,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72258120e38d87ac03fcdcc2f00e8025",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421182977,
-    "wof:lastmodified":1566646014,
+    "wof:lastmodified":1582319374,
     "wof:name":"Senseti",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/182/979/421182979.geojson
+++ b/data/421/182/979/421182979.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009354,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad3fb5085455310b17d10df9898c0ed3",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421182979,
-    "wof:lastmodified":1566646017,
+    "wof:lastmodified":1582319375,
     "wof:name":"Teupasenti",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/983/421182983.geojson
+++ b/data/421/182/983/421182983.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009354,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"232330e36e0bf043f75f7e18c3abd35e",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421182983,
-    "wof:lastmodified":1566646015,
+    "wof:lastmodified":1582319374,
     "wof:name":"Texigua",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/985/421182985.geojson
+++ b/data/421/182/985/421182985.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009354,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aaa085ca3517d48f1ecfb265b2162c2c",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421182985,
-    "wof:lastmodified":1566646024,
+    "wof:lastmodified":1582319379,
     "wof:name":"Tocoa",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/183/141/421183141.geojson
+++ b/data/421/183/141/421183141.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009359,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1b4654f6f06e52d69f0e89007c727e9",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421183141,
-    "wof:lastmodified":1566645990,
+    "wof:lastmodified":1582319364,
     "wof:name":"San Juan",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/183/293/421183293.geojson
+++ b/data/421/183/293/421183293.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009364,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8a7b789089ad9c3d683fbb7d07a07435",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421183293,
-    "wof:lastmodified":1566645987,
+    "wof:lastmodified":1582319363,
     "wof:name":"Sulaco",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/183/297/421183297.geojson
+++ b/data/421/183/297/421183297.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009364,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9f84782f649b75472e766c198c5ae1e",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421183297,
-    "wof:lastmodified":1566645990,
+    "wof:lastmodified":1582319364,
     "wof:name":"Atima",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/183/299/421183299.geojson
+++ b/data/421/183/299/421183299.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009364,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cce5115d097f4eeef1d418236197c4d",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421183299,
-    "wof:lastmodified":1566645990,
+    "wof:lastmodified":1582319364,
     "wof:name":"Azacualpa",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/183/301/421183301.geojson
+++ b/data/421/183/301/421183301.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009364,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b6dd8fe337aacc76671b323f3d9554d",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421183301,
-    "wof:lastmodified":1566645986,
+    "wof:lastmodified":1582319363,
     "wof:name":"Concepcion",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/183/303/421183303.geojson
+++ b/data/421/183/303/421183303.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009364,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a1a76b7df19ae3797d9b73d2dc3df6b0",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421183303,
-    "wof:lastmodified":1566645988,
+    "wof:lastmodified":1582319364,
     "wof:name":"Guarita",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/183/307/421183307.geojson
+++ b/data/421/183/307/421183307.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009365,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a26a10d16177973dc59e2808b57ae6a8",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421183307,
-    "wof:lastmodified":1566645985,
+    "wof:lastmodified":1582319362,
     "wof:name":"Sonaguera",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/183/317/421183317.geojson
+++ b/data/421/183/317/421183317.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009365,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5263621f3d6dd14630dd61022df8c749",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421183317,
-    "wof:lastmodified":1566645991,
+    "wof:lastmodified":1582319365,
     "wof:name":"Marcala",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/183/319/421183319.geojson
+++ b/data/421/183/319/421183319.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009365,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"daacbd04422c48688f16bf1e7f1d5cbb",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421183319,
-    "wof:lastmodified":1566645992,
+    "wof:lastmodified":1582319365,
     "wof:name":"La Iguala",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/183/321/421183321.geojson
+++ b/data/421/183/321/421183321.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009365,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3388a0747aad9e087ab25cdee4cd93e4",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421183321,
-    "wof:lastmodified":1566645994,
+    "wof:lastmodified":1582319366,
     "wof:name":"San Jeronimo",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/183/865/421183865.geojson
+++ b/data/421/183/865/421183865.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009389,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9472394bc056dc42307abfd5aaa1848",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421183865,
-    "wof:lastmodified":1566645989,
+    "wof:lastmodified":1582319364,
     "wof:name":"Dulce Nombre",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/184/149/421184149.geojson
+++ b/data/421/184/149/421184149.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009402,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d9962044220aa4261ae3d1e99418b21",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421184149,
-    "wof:lastmodified":1566645962,
+    "wof:lastmodified":1582319350,
     "wof:name":"San Antonio de Oriente",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/184/345/421184345.geojson
+++ b/data/421/184/345/421184345.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009408,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"79cf5297047a67aad5a9e09f84663e8c",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421184345,
-    "wof:lastmodified":1566645962,
+    "wof:lastmodified":1582319350,
     "wof:name":"Concepcion",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/184/463/421184463.geojson
+++ b/data/421/184/463/421184463.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009411,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"284cd7044870423779a4c2469ccbc547",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421184463,
-    "wof:lastmodified":1566645960,
+    "wof:lastmodified":1582319349,
     "wof:name":"Villa de San Francisco",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/184/465/421184465.geojson
+++ b/data/421/184/465/421184465.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009411,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"886d99602a364eb9e35ae84f5f0cfa9b",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421184465,
-    "wof:lastmodified":1566645960,
+    "wof:lastmodified":1582319349,
     "wof:name":"Villa Nueva",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/184/595/421184595.geojson
+++ b/data/421/184/595/421184595.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009416,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b863a6b490ee16aeef418e44cd4e6fab",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421184595,
-    "wof:lastmodified":1566645959,
+    "wof:lastmodified":1582319349,
     "wof:name":"Santa Ana",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/184/597/421184597.geojson
+++ b/data/421/184/597/421184597.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009416,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c48e3001e63f0a1e48dfc7fb66e88e8a",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421184597,
-    "wof:lastmodified":1566645961,
+    "wof:lastmodified":1582319350,
     "wof:name":"Villa de San Antonio",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/185/031/421185031.geojson
+++ b/data/421/185/031/421185031.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009430,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"751d2fcbce3916b065609df21b4c2142",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421185031,
-    "wof:lastmodified":1566646053,
+    "wof:lastmodified":1582319393,
     "wof:name":"Belen",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/185/035/421185035.geojson
+++ b/data/421/185/035/421185035.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009430,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"979b3ce6aa0cac94883a035d08c91244",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":421185035,
-    "wof:lastmodified":1566646055,
+    "wof:lastmodified":1582319394,
     "wof:name":"Choloma",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/185/037/421185037.geojson
+++ b/data/421/185/037/421185037.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009430,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd3b9ccc40f579e1308a1a718fa98d52",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421185037,
-    "wof:lastmodified":1566646054,
+    "wof:lastmodified":1582319394,
     "wof:name":"El Corpus",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/185/397/421185397.geojson
+++ b/data/421/185/397/421185397.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009442,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"302d2c4f496d9bc58fffaf22ca34381a",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421185397,
-    "wof:lastmodified":1566646051,
+    "wof:lastmodified":1582319392,
     "wof:name":"Yoro",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/186/027/421186027.geojson
+++ b/data/421/186/027/421186027.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009462,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c83c3e40e516a35de0aff9b227a8abd",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421186027,
-    "wof:lastmodified":1566645885,
+    "wof:lastmodified":1582319311,
     "wof:name":"San Juan",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/186/029/421186029.geojson
+++ b/data/421/186/029/421186029.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009462,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57e05e897513a99ff1a0928f180cafe3",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421186029,
-    "wof:lastmodified":1566645886,
+    "wof:lastmodified":1582319311,
     "wof:name":"San Manuel de Colohete",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/186/499/421186499.geojson
+++ b/data/421/186/499/421186499.geojson
@@ -223,7 +223,8 @@
     "qs:woe_id":107901,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "quattroshapes_pg"
+        "quattroshapes_pg",
+        "naturalearth"
     ],
     "wof:belongsto":[
         102191575,
@@ -243,6 +244,10 @@
     },
     "wof:country":"HN",
     "wof:created":1459009483,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "naturalearth"
+    ],
     "wof:geomhash":"f3d700bbaf05923e6fd1d1ef18856142",
     "wof:hierarchy":[
         {
@@ -254,7 +259,7 @@
         }
     ],
     "wof:id":421186499,
-    "wof:lastmodified":1566645885,
+    "wof:lastmodified":1582319311,
     "wof:name":"Trujillo",
     "wof:parent_id":421188783,
     "wof:placetype":"locality",

--- a/data/421/188/477/421188477.geojson
+++ b/data/421/188/477/421188477.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009560,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"89a230dce1b41af80a8072f43998043a",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421188477,
-    "wof:lastmodified":1566645847,
+    "wof:lastmodified":1582319290,
     "wof:name":"Yorito",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/188/479/421188479.geojson
+++ b/data/421/188/479/421188479.geojson
@@ -600,6 +600,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009560,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"63aa6eadb768c671e65a2fb1ee044823",
     "wof:hierarchy":[
         {
@@ -610,7 +613,7 @@
         }
     ],
     "wof:id":421188479,
-    "wof:lastmodified":1566645848,
+    "wof:lastmodified":1582319291,
     "wof:name":"Florida",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/188/481/421188481.geojson
+++ b/data/421/188/481/421188481.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009560,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"af9e9768c645b8af2d9ae664fef5c28a",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421188481,
-    "wof:lastmodified":1566645866,
+    "wof:lastmodified":1582319301,
     "wof:name":"Fraternidad",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/188/483/421188483.geojson
+++ b/data/421/188/483/421188483.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009560,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d60ce904e276e138d55e456a49ea13f",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421188483,
-    "wof:lastmodified":1566645847,
+    "wof:lastmodified":1582319290,
     "wof:name":"Guimaca",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/188/485/421188485.geojson
+++ b/data/421/188/485/421188485.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009560,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1dc75e98279b1125d51053a984711ca",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421188485,
-    "wof:lastmodified":1566645846,
+    "wof:lastmodified":1582319289,
     "wof:name":"Lucerna",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/188/487/421188487.geojson
+++ b/data/421/188/487/421188487.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009561,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f48a96e312b329e218d2aac858a61e6f",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421188487,
-    "wof:lastmodified":1566645867,
+    "wof:lastmodified":1582319301,
     "wof:name":"Guajiquiro",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/188/491/421188491.geojson
+++ b/data/421/188/491/421188491.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009561,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"16c142dfb40ce785c02f7857e339cdcb",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421188491,
-    "wof:lastmodified":1566645850,
+    "wof:lastmodified":1582319292,
     "wof:name":"Gualaco",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/188/495/421188495.geojson
+++ b/data/421/188/495/421188495.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009561,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6dffa4da4aa25cde6318e781b2d7894a",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421188495,
-    "wof:lastmodified":1566645868,
+    "wof:lastmodified":1582319302,
     "wof:name":"La Labor",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/188/497/421188497.geojson
+++ b/data/421/188/497/421188497.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009561,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b751c9089de4c69a5a68b0b78b73f75b",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":421188497,
-    "wof:lastmodified":1566645849,
+    "wof:lastmodified":1582319291,
     "wof:name":"La Esperanza",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/188/501/421188501.geojson
+++ b/data/421/188/501/421188501.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009561,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"014ffcb4bea08148b7e1a01035a09cc0",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421188501,
-    "wof:lastmodified":1566645860,
+    "wof:lastmodified":1582319297,
     "wof:name":"Minas de Oro",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/188/503/421188503.geojson
+++ b/data/421/188/503/421188503.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009561,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ee174f8f486c48c8abbc11a70251bb3",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421188503,
-    "wof:lastmodified":1566645845,
+    "wof:lastmodified":1582319289,
     "wof:name":"Namasigue",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/188/505/421188505.geojson
+++ b/data/421/188/505/421188505.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009561,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5da27c17877915feb85230f220c41632",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421188505,
-    "wof:lastmodified":1566645843,
+    "wof:lastmodified":1582319288,
     "wof:name":"Liure",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/188/509/421188509.geojson
+++ b/data/421/188/509/421188509.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009561,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ba6d7717644a9ce4d0e8b74f965414f5",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421188509,
-    "wof:lastmodified":1566645865,
+    "wof:lastmodified":1582319300,
     "wof:name":"Naranjito",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/188/511/421188511.geojson
+++ b/data/421/188/511/421188511.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009561,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cff1b44cb47b17cb8cc4a13d17887796",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421188511,
-    "wof:lastmodified":1566645857,
+    "wof:lastmodified":1582319295,
     "wof:name":"San Agustin",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/188/513/421188513.geojson
+++ b/data/421/188/513/421188513.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009561,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"528c92504a46c3a9c4881584e21f587f",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421188513,
-    "wof:lastmodified":1566645874,
+    "wof:lastmodified":1582319305,
     "wof:name":"San Andres",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/188/515/421188515.geojson
+++ b/data/421/188/515/421188515.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009565,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5679be734fb6491af3c8d277b15bc429",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421188515,
-    "wof:lastmodified":1566645876,
+    "wof:lastmodified":1582319306,
     "wof:name":"San Antonio de Cortes",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/188/519/421188519.geojson
+++ b/data/421/188/519/421188519.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009565,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3826a78692581c18440757d1eca36946",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421188519,
-    "wof:lastmodified":1566645852,
+    "wof:lastmodified":1582319293,
     "wof:name":"San Pedro Tutule",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/188/521/421188521.geojson
+++ b/data/421/188/521/421188521.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009565,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"71b4949fd6a73e19039d674f1b53b478",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421188521,
-    "wof:lastmodified":1566645851,
+    "wof:lastmodified":1582319293,
     "wof:name":"San Pedro Zacapa",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/188/523/421188523.geojson
+++ b/data/421/188/523/421188523.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009565,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60dca7b13d182033a9ca8ba5ed4b81d7",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421188523,
-    "wof:lastmodified":1566645876,
+    "wof:lastmodified":1582319306,
     "wof:name":"San Sebastian",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/188/527/421188527.geojson
+++ b/data/421/188/527/421188527.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009565,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67a60b63a4a8e68c3422728540d47623",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421188527,
-    "wof:lastmodified":1566645853,
+    "wof:lastmodified":1582319293,
     "wof:name":"Vallecillo",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/188/529/421188529.geojson
+++ b/data/421/188/529/421188529.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009565,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4bec69f78aba17e1afc98abe178ec73",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421188529,
-    "wof:lastmodified":1566645855,
+    "wof:lastmodified":1582319294,
     "wof:name":"Trojes",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/188/531/421188531.geojson
+++ b/data/421/188/531/421188531.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009568,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72dc63ea65402c95f3dc3a8a9ba16a8a",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421188531,
-    "wof:lastmodified":1566645865,
+    "wof:lastmodified":1582319300,
     "wof:name":"Veracruz",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/188/533/421188533.geojson
+++ b/data/421/188/533/421188533.geojson
@@ -206,6 +206,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009568,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"328a29aed6a0d7e4fcf9b6a05e5fedbb",
     "wof:hierarchy":[
         {
@@ -216,7 +219,7 @@
         }
     ],
     "wof:id":421188533,
-    "wof:lastmodified":1566645843,
+    "wof:lastmodified":1582319287,
     "wof:name":"Yuscaran",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/188/755/421188755.geojson
+++ b/data/421/188/755/421188755.geojson
@@ -140,6 +140,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"921def41acc87a70d60091a524f97e0d",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":421188755,
-    "wof:lastmodified":1566645841,
+    "wof:lastmodified":1582319286,
     "wof:name":"El Progreso",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/188/757/421188757.geojson
+++ b/data/421/188/757/421188757.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009577,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47eafcf3356e25af5646e62d785c6d1b",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421188757,
-    "wof:lastmodified":1566645865,
+    "wof:lastmodified":1582319300,
     "wof:name":"Gracias",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/188/763/421188763.geojson
+++ b/data/421/188/763/421188763.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009578,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"25cc687d6f3d28ecf8c1ff48e35cc9b2",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421188763,
-    "wof:lastmodified":1566645841,
+    "wof:lastmodified":1582319286,
     "wof:name":"Balfate",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/188/765/421188765.geojson
+++ b/data/421/188/765/421188765.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009578,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c76b41d38215b3a0c1af9424342ce117",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421188765,
-    "wof:lastmodified":1566645844,
+    "wof:lastmodified":1582319288,
     "wof:name":"Guanaja",
     "wof:parent_id":85671869,
     "wof:placetype":"county",

--- a/data/421/188/767/421188767.geojson
+++ b/data/421/188/767/421188767.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009578,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"248318e0bcbe861e99e482bc60d46448",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421188767,
-    "wof:lastmodified":1566645861,
+    "wof:lastmodified":1582319298,
     "wof:name":"Jutiapa",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/188/769/421188769.geojson
+++ b/data/421/188/769/421188769.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009578,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53a908d1f1d17f09833d8dbaeef46307",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421188769,
-    "wof:lastmodified":1566645861,
+    "wof:lastmodified":1582319298,
     "wof:name":"Choluteca",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/188/771/421188771.geojson
+++ b/data/421/188/771/421188771.geojson
@@ -481,6 +481,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009578,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8702804b38c116a1a2c7fe6767a4ddc",
     "wof:hierarchy":[
         {
@@ -491,7 +494,7 @@
         }
     ],
     "wof:id":421188771,
-    "wof:lastmodified":1566645853,
+    "wof:lastmodified":1582319293,
     "wof:name":"Las Vegas",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/188/773/421188773.geojson
+++ b/data/421/188/773/421188773.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009578,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"147f91398f856ad9d7f0adbdbe78e31a",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421188773,
-    "wof:lastmodified":1566645875,
+    "wof:lastmodified":1582319306,
     "wof:name":"Lejamani",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/188/775/421188775.geojson
+++ b/data/421/188/775/421188775.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009578,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03729ed76c936a25c3ea4c137b9891c3",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421188775,
-    "wof:lastmodified":1566645869,
+    "wof:lastmodified":1582319303,
     "wof:name":"Marcovia",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/188/779/421188779.geojson
+++ b/data/421/188/779/421188779.geojson
@@ -481,6 +481,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009578,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29ad9025f76e7ecfa2eb627b28f4c0ee",
     "wof:hierarchy":[
         {
@@ -491,7 +494,7 @@
         }
     ],
     "wof:id":421188779,
-    "wof:lastmodified":1566645859,
+    "wof:lastmodified":1582319296,
     "wof:name":"La Paz",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/188/781/421188781.geojson
+++ b/data/421/188/781/421188781.geojson
@@ -197,6 +197,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009578,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ebb5e2df9ef5960f064c5f97af0a7472",
     "wof:hierarchy":[
         {
@@ -207,7 +210,7 @@
         }
     ],
     "wof:id":421188781,
-    "wof:lastmodified":1566645873,
+    "wof:lastmodified":1582319305,
     "wof:name":"Siguatepeque",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/188/783/421188783.geojson
+++ b/data/421/188/783/421188783.geojson
@@ -199,6 +199,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009578,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b969166ce332e01d2555b6a1cfb21a91",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":421188783,
-    "wof:lastmodified":1566645857,
+    "wof:lastmodified":1582319296,
     "wof:name":"Trujillo",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/190/809/421190809.geojson
+++ b/data/421/190/809/421190809.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009669,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"51c2309f57b4768345c5faf9fd157f8b",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421190809,
-    "wof:lastmodified":1566645946,
+    "wof:lastmodified":1582319344,
     "wof:name":"Proteccion",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/191/079/421191079.geojson
+++ b/data/421/191/079/421191079.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009679,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5dfa455d84d80b13bc5b7633d70b976",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421191079,
-    "wof:lastmodified":1566645918,
+    "wof:lastmodified":1582319331,
     "wof:name":"Ajuterique",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/191/083/421191083.geojson
+++ b/data/421/191/083/421191083.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009679,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"df1819eab2e78521ab94ee0d67a2ae3e",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421191083,
-    "wof:lastmodified":1566645919,
+    "wof:lastmodified":1582319331,
     "wof:name":"Alauca",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/191/085/421191085.geojson
+++ b/data/421/191/085/421191085.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009679,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d726ba8e3e899fae04589c4b06eaa78",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421191085,
-    "wof:lastmodified":1566645921,
+    "wof:lastmodified":1582319332,
     "wof:name":"Alianza",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/191/087/421191087.geojson
+++ b/data/421/191/087/421191087.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009679,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78028cf777014b0a172fe2274d178f60",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421191087,
-    "wof:lastmodified":1566645937,
+    "wof:lastmodified":1582319340,
     "wof:name":"Morazan",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/191/089/421191089.geojson
+++ b/data/421/191/089/421191089.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009679,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f9469359bd675abcf418685bb06f87d",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421191089,
-    "wof:lastmodified":1566645936,
+    "wof:lastmodified":1582319339,
     "wof:name":"Limon",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/191/091/421191091.geojson
+++ b/data/421/191/091/421191091.geojson
@@ -285,6 +285,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009679,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bd2a072271035afee24489b2d49eda5",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         }
     ],
     "wof:id":421191091,
-    "wof:lastmodified":1566645924,
+    "wof:lastmodified":1582319334,
     "wof:name":"Victoria",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/191/093/421191093.geojson
+++ b/data/421/191/093/421191093.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009679,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9d1cc394c0cd3e6a71e030d8652f5216",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421191093,
-    "wof:lastmodified":1566645942,
+    "wof:lastmodified":1582319342,
     "wof:name":"Valladolid",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/191/339/421191339.geojson
+++ b/data/421/191/339/421191339.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f58021fbec3e6aef412895344d3c8c65",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421191339,
-    "wof:lastmodified":1566645916,
+    "wof:lastmodified":1582319330,
     "wof:name":"Cabanas",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/191/341/421191341.geojson
+++ b/data/421/191/341/421191341.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d73b561e087c1fb3e6539a62eab05f57",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421191341,
-    "wof:lastmodified":1566645928,
+    "wof:lastmodified":1582319336,
     "wof:name":"Camasca",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/191/343/421191343.geojson
+++ b/data/421/191/343/421191343.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f0d9ead4ef937194210902bd9544b6a9",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421191343,
-    "wof:lastmodified":1566645945,
+    "wof:lastmodified":1582319343,
     "wof:name":"Chinacla",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/191/345/421191345.geojson
+++ b/data/421/191/345/421191345.geojson
@@ -121,6 +121,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eddefe897660c0fab725b8f22dd6eb21",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":421191345,
-    "wof:lastmodified":1566645943,
+    "wof:lastmodified":1582319342,
     "wof:name":"Concepcion del Norte",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/191/347/421191347.geojson
+++ b/data/421/191/347/421191347.geojson
@@ -196,6 +196,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2531e58df7d63044ef330a74ddf640a0",
     "wof:hierarchy":[
         {
@@ -206,7 +209,7 @@
         }
     ],
     "wof:id":421191347,
-    "wof:lastmodified":1566645931,
+    "wof:lastmodified":1582319337,
     "wof:name":"Concordia",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/349/421191349.geojson
+++ b/data/421/191/349/421191349.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1984bb9cafac331410ebf01d6450f04b",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421191349,
-    "wof:lastmodified":1566645930,
+    "wof:lastmodified":1582319337,
     "wof:name":"Guayape",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/353/421191353.geojson
+++ b/data/421/191/353/421191353.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e576f1e4a73eaf446ab7729727a81778",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421191353,
-    "wof:lastmodified":1566645915,
+    "wof:lastmodified":1582319329,
     "wof:name":"Humuya",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/191/355/421191355.geojson
+++ b/data/421/191/355/421191355.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"007f713627b4616ca5504738ff35b1ba",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421191355,
-    "wof:lastmodified":1566645917,
+    "wof:lastmodified":1582319330,
     "wof:name":"La Trinidad",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/191/357/421191357.geojson
+++ b/data/421/191/357/421191357.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5dd4a937fc4de2a66d5474a1763fb252",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421191357,
-    "wof:lastmodified":1566645934,
+    "wof:lastmodified":1582319338,
     "wof:name":"Nuevo Celilac",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/191/359/421191359.geojson
+++ b/data/421/191/359/421191359.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ff90bfc5c60b75773ee67579b68fd06",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421191359,
-    "wof:lastmodified":1566645933,
+    "wof:lastmodified":1582319338,
     "wof:name":"Ojos de Agua",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/191/361/421191361.geojson
+++ b/data/421/191/361/421191361.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cf3a4255eed5acf76c17d4004f39d076",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421191361,
-    "wof:lastmodified":1566645932,
+    "wof:lastmodified":1582319338,
     "wof:name":"Orica",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/191/363/421191363.geojson
+++ b/data/421/191/363/421191363.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"004e5a15414aa425ed621eae122bb439",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421191363,
-    "wof:lastmodified":1566645917,
+    "wof:lastmodified":1582319330,
     "wof:name":"Patuca",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/365/421191365.geojson
+++ b/data/421/191/365/421191365.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009689,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8d46bb872b3277c8a75a7177da297ec",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421191365,
-    "wof:lastmodified":1566645915,
+    "wof:lastmodified":1582319329,
     "wof:name":"San Miguelito",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/191/367/421191367.geojson
+++ b/data/421/191/367/421191367.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a519048f9a2599555ff2b7cb828e79ff",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421191367,
-    "wof:lastmodified":1566645935,
+    "wof:lastmodified":1582319339,
     "wof:name":"San Nicolas",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/191/373/421191373.geojson
+++ b/data/421/191/373/421191373.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"715d1a173131afd1b00e75dc82e2dd3d",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421191373,
-    "wof:lastmodified":1566645944,
+    "wof:lastmodified":1582319343,
     "wof:name":"San Vicente Centenario",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/191/375/421191375.geojson
+++ b/data/421/191/375/421191375.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8a3527c91e8cec1ab43e12bc97890f4a",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":421191375,
-    "wof:lastmodified":1566645944,
+    "wof:lastmodified":1582319343,
     "wof:name":"Santa Elena",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/191/379/421191379.geojson
+++ b/data/421/191/379/421191379.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5e0918da691e949a6d33fac4147f6974",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421191379,
-    "wof:lastmodified":1566645927,
+    "wof:lastmodified":1582319335,
     "wof:name":"Santa Maria",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/191/381/421191381.geojson
+++ b/data/421/191/381/421191381.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"97285e0d6166136cff371885624f56e4",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421191381,
-    "wof:lastmodified":1566645945,
+    "wof:lastmodified":1582319343,
     "wof:name":"Santa Rita",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/191/383/421191383.geojson
+++ b/data/421/191/383/421191383.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb8bb379d1a423127efb30c6c1c07944",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421191383,
-    "wof:lastmodified":1566645929,
+    "wof:lastmodified":1582319336,
     "wof:name":"Silca",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/385/421191385.geojson
+++ b/data/421/191/385/421191385.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"04e0f8b8aff1f82e5451db93b3500817",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421191385,
-    "wof:lastmodified":1566645929,
+    "wof:lastmodified":1582319336,
     "wof:name":"Soledad",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/191/389/421191389.geojson
+++ b/data/421/191/389/421191389.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d80be798c3ae32d2f410c5dd0069aa6",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421191389,
-    "wof:lastmodified":1566645942,
+    "wof:lastmodified":1582319342,
     "wof:name":"Yarula",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/191/391/421191391.geojson
+++ b/data/421/191/391/421191391.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4329c4b52e4448d611da218bc9aa5192",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421191391,
-    "wof:lastmodified":1566645915,
+    "wof:lastmodified":1582319329,
     "wof:name":"Yauyupe",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/191/393/421191393.geojson
+++ b/data/421/191/393/421191393.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82abeb8fd9885ae5b00aae3455cbb15e",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421191393,
-    "wof:lastmodified":1566645935,
+    "wof:lastmodified":1582319339,
     "wof:name":"Yocon",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/601/421191601.geojson
+++ b/data/421/191/601/421191601.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009698,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d105a2cbcc4654152c3d94eee48e362b",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421191601,
-    "wof:lastmodified":1566645941,
+    "wof:lastmodified":1582319342,
     "wof:name":"Reitoca",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/191/669/421191669.geojson
+++ b/data/421/191/669/421191669.geojson
@@ -191,6 +191,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009701,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"10436e0f3777d7aab0f8abc5c7cfe459",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
         }
     ],
     "wof:id":421191669,
-    "wof:lastmodified":1566645926,
+    "wof:lastmodified":1582319335,
     "wof:name":"Campamento",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/671/421191671.geojson
+++ b/data/421/191/671/421191671.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009701,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b3271601fa389adc0b2e8e6cc04704c1",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421191671,
-    "wof:lastmodified":1566645939,
+    "wof:lastmodified":1582319340,
     "wof:name":"Marale",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/191/673/421191673.geojson
+++ b/data/421/191/673/421191673.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009701,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2224cecc8c2f5b3fce6504a88b89454c",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421191673,
-    "wof:lastmodified":1566645920,
+    "wof:lastmodified":1582319332,
     "wof:name":"Jocon",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/191/677/421191677.geojson
+++ b/data/421/191/677/421191677.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009701,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2add53b73e9b8f1ebed0ddfdb4f1b95d",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421191677,
-    "wof:lastmodified":1566645940,
+    "wof:lastmodified":1582319341,
     "wof:name":"San Ignacio",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/191/679/421191679.geojson
+++ b/data/421/191/679/421191679.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009701,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ecadf10480514b00372068fff219f243",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421191679,
-    "wof:lastmodified":1566645940,
+    "wof:lastmodified":1582319341,
     "wof:name":"San Isidro",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/191/683/421191683.geojson
+++ b/data/421/191/683/421191683.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009701,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c3e4529b789baa7ff4c103e1d264a29b",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421191683,
-    "wof:lastmodified":1566645940,
+    "wof:lastmodified":1582319341,
     "wof:name":"Tomala",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/192/627/421192627.geojson
+++ b/data/421/192/627/421192627.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009743,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86c31d53c534800895616b4531fca453",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421192627,
-    "wof:lastmodified":1566645786,
+    "wof:lastmodified":1582319261,
     "wof:name":"Jano",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/193/149/421193149.geojson
+++ b/data/421/193/149/421193149.geojson
@@ -286,6 +286,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009762,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"f6d26a6b0d70ba8071b6f2a11cb5b891",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         }
     ],
     "wof:id":421193149,
-    "wof:lastmodified":1566645803,
+    "wof:lastmodified":1582319269,
     "wof:name":"Choluteca",
     "wof:parent_id":421188769,
     "wof:placetype":"locality",

--- a/data/421/193/293/421193293.geojson
+++ b/data/421/193/293/421193293.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009766,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"49a99ebd17bc0204cc239d05aca33095",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421193293,
-    "wof:lastmodified":1566645797,
+    "wof:lastmodified":1582319266,
     "wof:name":"Cololaca",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/193/297/421193297.geojson
+++ b/data/421/193/297/421193297.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009766,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d71e068d981245d28925ffec555ee78b",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421193297,
-    "wof:lastmodified":1566645803,
+    "wof:lastmodified":1582319269,
     "wof:name":"Chinda",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/193/299/421193299.geojson
+++ b/data/421/193/299/421193299.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009766,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e8effa0c010f99789ea8e03890746a7",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421193299,
-    "wof:lastmodified":1566645803,
+    "wof:lastmodified":1582319269,
     "wof:name":"San Buenaventura",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/193/573/421193573.geojson
+++ b/data/421/193/573/421193573.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009775,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8639bb89cbdf0fbdbeb7a04ab1fe0a73",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421193573,
-    "wof:lastmodified":1566645798,
+    "wof:lastmodified":1582319267,
     "wof:name":"Ahuas",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/421/193/683/421193683.geojson
+++ b/data/421/193/683/421193683.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009779,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cbcf28481a0cb651d38db0c5bdd8e65b",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":421193683,
-    "wof:lastmodified":1566645801,
+    "wof:lastmodified":1582319268,
     "wof:name":"Alubaren",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/193/685/421193685.geojson
+++ b/data/421/193/685/421193685.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009779,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b735619ceb79d6b7dee9e94f53626db",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421193685,
-    "wof:lastmodified":1566645800,
+    "wof:lastmodified":1582319268,
     "wof:name":"Apacilagua",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/193/687/421193687.geojson
+++ b/data/421/193/687/421193687.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009779,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"328508894ca0fed7dfa8b324d2957d59",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421193687,
-    "wof:lastmodified":1566645796,
+    "wof:lastmodified":1582319266,
     "wof:name":"Masaguara",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/193/689/421193689.geojson
+++ b/data/421/193/689/421193689.geojson
@@ -108,6 +108,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009780,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"80b3e79fe4f6d568658359523832c766",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":421193689,
-    "wof:lastmodified":1566645795,
+    "wof:lastmodified":1582319266,
     "wof:name":"Mercedes de Oriente",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/193/695/421193695.geojson
+++ b/data/421/193/695/421193695.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009780,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4065817797287bf2a8c59e87e416ad69",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421193695,
-    "wof:lastmodified":1566645798,
+    "wof:lastmodified":1582319267,
     "wof:name":"San Antonio",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/193/697/421193697.geojson
+++ b/data/421/193/697/421193697.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009780,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f0aff7ee122c8fb07813775975474b6",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421193697,
-    "wof:lastmodified":1566645802,
+    "wof:lastmodified":1582319269,
     "wof:name":"San Francisco de Becerra",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/193/699/421193699.geojson
+++ b/data/421/193/699/421193699.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009780,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"563291bcf4260dad3a98052f89a0222a",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421193699,
-    "wof:lastmodified":1566645801,
+    "wof:lastmodified":1582319268,
     "wof:name":"San Francisco de Ojuera",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/193/701/421193701.geojson
+++ b/data/421/193/701/421193701.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009780,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4f3af190d3d9f0a5e3d37becff54942",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421193701,
-    "wof:lastmodified":1566645795,
+    "wof:lastmodified":1582319265,
     "wof:name":"San Jorge",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/194/673/421194673.geojson
+++ b/data/421/194/673/421194673.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009815,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ded262311d18fce306423bd59ab2763c",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421194673,
-    "wof:lastmodified":1566645790,
+    "wof:lastmodified":1582319263,
     "wof:name":"Potrerillos",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/194/943/421194943.geojson
+++ b/data/421/194/943/421194943.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009825,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6535b7887368453d2563e46735dbbbed",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421194943,
-    "wof:lastmodified":1566645794,
+    "wof:lastmodified":1582319264,
     "wof:name":"Corquin",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/194/945/421194945.geojson
+++ b/data/421/194/945/421194945.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009825,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fda2988215a22f7a4d550b074c12bde6",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421194945,
-    "wof:lastmodified":1566645793,
+    "wof:lastmodified":1582319264,
     "wof:name":"Curaren",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/194/947/421194947.geojson
+++ b/data/421/194/947/421194947.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009825,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dce60bcbd2f5177e60e639cba2b79858",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421194947,
-    "wof:lastmodified":1566645791,
+    "wof:lastmodified":1582319263,
     "wof:name":"La Jigua",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/194/949/421194949.geojson
+++ b/data/421/194/949/421194949.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009825,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b366b170af52c03496203f1aa2ae462b",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421194949,
-    "wof:lastmodified":1566645792,
+    "wof:lastmodified":1582319264,
     "wof:name":"La Libertad",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/194/955/421194955.geojson
+++ b/data/421/194/955/421194955.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009825,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aef83004d923b05008f1e47998428440",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421194955,
-    "wof:lastmodified":1566645789,
+    "wof:lastmodified":1582319263,
     "wof:name":"Las Lajas",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/194/957/421194957.geojson
+++ b/data/421/194/957/421194957.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009825,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"10cc522aed4192fe49354265d7aab079",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421194957,
-    "wof:lastmodified":1566645792,
+    "wof:lastmodified":1582319264,
     "wof:name":"Lauterique",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/194/961/421194961.geojson
+++ b/data/421/194/961/421194961.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009826,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"70ddaf4f9b2b60b3bcc534fbc2f82eb9",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421194961,
-    "wof:lastmodified":1566645792,
+    "wof:lastmodified":1582319264,
     "wof:name":"Pimienta",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/194/963/421194963.geojson
+++ b/data/421/194/963/421194963.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009826,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"df2c0a6e1fecb6e47e5a2f6c95fb0d2a",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421194963,
-    "wof:lastmodified":1566645788,
+    "wof:lastmodified":1582319262,
     "wof:name":"Piraera",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/197/119/421197119.geojson
+++ b/data/421/197/119/421197119.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009903,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2318e98c7f1c03cc2575fa69b28dc98f",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421197119,
-    "wof:lastmodified":1566645948,
+    "wof:lastmodified":1582319344,
     "wof:name":"San Francisco de Yojoa",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/198/881/421198881.geojson
+++ b/data/421/198/881/421198881.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009964,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fdee0e843a95d114aa1f22363cb615ac",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421198881,
-    "wof:lastmodified":1566645908,
+    "wof:lastmodified":1582319325,
     "wof:name":"Cedros",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/198/883/421198883.geojson
+++ b/data/421/198/883/421198883.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009964,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"620c6754e52792db3ce9a1b833117563",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421198883,
-    "wof:lastmodified":1566645911,
+    "wof:lastmodified":1582319326,
     "wof:name":"Harizona",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/198/885/421198885.geojson
+++ b/data/421/198/885/421198885.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009964,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2b740d82901b394bf1a6f0ee37f0f79c",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":421198885,
-    "wof:lastmodified":1566645913,
+    "wof:lastmodified":1582319327,
     "wof:name":"San Antonio de Flores",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/198/887/421198887.geojson
+++ b/data/421/198/887/421198887.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009964,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f51724802ce1145ee1ac0e184b5f1c5",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421198887,
-    "wof:lastmodified":1566645908,
+    "wof:lastmodified":1582319325,
     "wof:name":"San Francisco de la Paz",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/198/889/421198889.geojson
+++ b/data/421/198/889/421198889.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009964,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7bc3bcb0c4e15885665347614e4752c1",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421198889,
-    "wof:lastmodified":1566645907,
+    "wof:lastmodified":1582319325,
     "wof:name":"San Jose de Comayagua",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/198/891/421198891.geojson
+++ b/data/421/198/891/421198891.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009965,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ac442d6799f1c3d7a03f4ad432ba259",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421198891,
-    "wof:lastmodified":1566645913,
+    "wof:lastmodified":1582319328,
     "wof:name":"San Jose del Potrero",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/198/895/421198895.geojson
+++ b/data/421/198/895/421198895.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459009965,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6aa1b81d20b2e8ed7380e40190926575",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421198895,
-    "wof:lastmodified":1566645911,
+    "wof:lastmodified":1582319326,
     "wof:name":"San Jose",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/199/873/421199873.geojson
+++ b/data/421/199/873/421199873.geojson
@@ -187,6 +187,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010003,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"327f1e73159eda4a0a7a5be09ae666ac",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         }
     ],
     "wof:id":421199873,
-    "wof:lastmodified":1566645950,
+    "wof:lastmodified":1582319345,
     "wof:name":"San Pedro",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/199/915/421199915.geojson
+++ b/data/421/199/915/421199915.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010005,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2006681a04a0b07cb70f19d44e4a13f7",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421199915,
-    "wof:lastmodified":1566645950,
+    "wof:lastmodified":1582319345,
     "wof:name":"Guata",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/199/961/421199961.geojson
+++ b/data/421/199/961/421199961.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010006,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c6eb5456f13f14873a1172435c54a663",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421199961,
-    "wof:lastmodified":1566645951,
+    "wof:lastmodified":1582319345,
     "wof:name":"Dulce nombre de Culmi",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/199/965/421199965.geojson
+++ b/data/421/199/965/421199965.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010006,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5cf0f2dfab76f5a5046e8de6605a95a2",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421199965,
-    "wof:lastmodified":1566645949,
+    "wof:lastmodified":1582319344,
     "wof:name":"San Matias",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/199/967/421199967.geojson
+++ b/data/421/199/967/421199967.geojson
@@ -301,6 +301,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010006,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7250556064b17a41033f428c616cefe",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
         }
     ],
     "wof:id":421199967,
-    "wof:lastmodified":1566645952,
+    "wof:lastmodified":1582319346,
     "wof:name":"Trinidad",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/200/541/421200541.geojson
+++ b/data/421/200/541/421200541.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010029,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee814ead551f656d79fdf31207d7ca52",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421200541,
-    "wof:lastmodified":1566645954,
+    "wof:lastmodified":1582319347,
     "wof:name":"Cane",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/200/543/421200543.geojson
+++ b/data/421/200/543/421200543.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010029,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d75b02c03b3e63434804c3ba75efd4f5",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421200543,
-    "wof:lastmodified":1566645953,
+    "wof:lastmodified":1582319346,
     "wof:name":"Caridad",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/200/721/421200721.geojson
+++ b/data/421/200/721/421200721.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010036,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e7099e84a15d2440806ecb30df4f15b",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421200721,
-    "wof:lastmodified":1566645954,
+    "wof:lastmodified":1582319347,
     "wof:name":"San Luis",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/200/723/421200723.geojson
+++ b/data/421/200/723/421200723.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010036,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb51aae6d965184fbdfb41d844aedebc",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421200723,
-    "wof:lastmodified":1566645953,
+    "wof:lastmodified":1582319346,
     "wof:name":"Sta. Ana de Yusguare",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/201/043/421201043.geojson
+++ b/data/421/201/043/421201043.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010049,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc0f93d4a917ff4b7e18eb1946ba9d47",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421201043,
-    "wof:lastmodified":1566645957,
+    "wof:lastmodified":1582319348,
     "wof:name":"El Negrito",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/201/045/421201045.geojson
+++ b/data/421/201/045/421201045.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010050,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23e61c526edf241ab807d79f75b892a2",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":421201045,
-    "wof:lastmodified":1566645956,
+    "wof:lastmodified":1582319347,
     "wof:name":"San Luis",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/201/047/421201047.geojson
+++ b/data/421/201/047/421201047.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010050,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b8c7566dbbced02dae568c7c6ce3c5b",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421201047,
-    "wof:lastmodified":1566645955,
+    "wof:lastmodified":1582319347,
     "wof:name":"Tatumbla",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/202/141/421202141.geojson
+++ b/data/421/202/141/421202141.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010106,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"723111e417d868a9fc5ed74cc80a5c8f",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":421202141,
-    "wof:lastmodified":1566645828,
+    "wof:lastmodified":1582319282,
     "wof:name":"Valle de \u00c1ngeles",
     "wof:parent_id":421204281,
     "wof:placetype":"locality",

--- a/data/421/202/499/421202499.geojson
+++ b/data/421/202/499/421202499.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010120,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"340709895a013cf76cc53475afcd0aa7",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421202499,
-    "wof:lastmodified":1566645825,
+    "wof:lastmodified":1582319281,
     "wof:name":"San Juan de Opoa",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/202/501/421202501.geojson
+++ b/data/421/202/501/421202501.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010120,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"462754e27632444c31e508ba84e57c69",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":421202501,
-    "wof:lastmodified":1566645826,
+    "wof:lastmodified":1582319281,
     "wof:name":"San Juan de Flores",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/202/525/421202525.geojson
+++ b/data/421/202/525/421202525.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010121,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f33f4bd43035aa66991ebea23ca4bf7",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":421202525,
-    "wof:lastmodified":1566645827,
+    "wof:lastmodified":1582319281,
     "wof:name":"Utila",
     "wof:parent_id":85671869,
     "wof:placetype":"county",

--- a/data/421/203/399/421203399.geojson
+++ b/data/421/203/399/421203399.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010150,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c80669726bcba8af0db0e652eb32245",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421203399,
-    "wof:lastmodified":1566645814,
+    "wof:lastmodified":1582319275,
     "wof:name":"El Rosario",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/203/401/421203401.geojson
+++ b/data/421/203/401/421203401.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db87cbfc49adc97729d37ac4f8fcce13",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421203401,
-    "wof:lastmodified":1566645818,
+    "wof:lastmodified":1582319277,
     "wof:name":"Esquias",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/203/403/421203403.geojson
+++ b/data/421/203/403/421203403.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b7decf0d5a0baed67e43cfc726dfcdbd",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421203403,
-    "wof:lastmodified":1566645824,
+    "wof:lastmodified":1582319280,
     "wof:name":"Goascoran",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/203/405/421203405.geojson
+++ b/data/421/203/405/421203405.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"93250bb03b5eea4db4ebf186977fd637",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421203405,
-    "wof:lastmodified":1566645824,
+    "wof:lastmodified":1582319280,
     "wof:name":"Gualala",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/203/407/421203407.geojson
+++ b/data/421/203/407/421203407.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f33bf6fc5adb77d0de5f0bb893c5a677",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421203407,
-    "wof:lastmodified":1566645820,
+    "wof:lastmodified":1582319278,
     "wof:name":"Guarizama",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/203/409/421203409.geojson
+++ b/data/421/203/409/421203409.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66dd18c8e8e00a9dcd24726738748f62",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421203409,
-    "wof:lastmodified":1566645819,
+    "wof:lastmodified":1582319278,
     "wof:name":"Magdalena",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/203/413/421203413.geojson
+++ b/data/421/203/413/421203413.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1316eef8be5b398b79373024ae9449ea",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421203413,
-    "wof:lastmodified":1566645816,
+    "wof:lastmodified":1582319276,
     "wof:name":"Mangulile",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/203/415/421203415.geojson
+++ b/data/421/203/415/421203415.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bd4765df45f2674c8566b656ec06d17",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421203415,
-    "wof:lastmodified":1566645817,
+    "wof:lastmodified":1582319276,
     "wof:name":"San Antonio del Norte",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/203/417/421203417.geojson
+++ b/data/421/203/417/421203417.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cac4a610a1c9f1fca632e38139e7df9f",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421203417,
-    "wof:lastmodified":1566645822,
+    "wof:lastmodified":1582319279,
     "wof:name":"San Francisco",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/203/419/421203419.geojson
+++ b/data/421/203/419/421203419.geojson
@@ -581,6 +581,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fecbfa3f3fe0f7f910ea319f69b28944",
     "wof:hierarchy":[
         {
@@ -591,7 +594,7 @@
         }
     ],
     "wof:id":421203419,
-    "wof:lastmodified":1566645821,
+    "wof:lastmodified":1582319278,
     "wof:name":"San Francisco",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/203/421/421203421.geojson
+++ b/data/421/203/421/421203421.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d4ce2e25a2c94a0775cfa27b105b07e",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421203421,
-    "wof:lastmodified":1566645822,
+    "wof:lastmodified":1582319279,
     "wof:name":"San Isidro",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/203/423/421203423.geojson
+++ b/data/421/203/423/421203423.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67c5f66dd763b000471f37499817d118",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421203423,
-    "wof:lastmodified":1566645817,
+    "wof:lastmodified":1582319277,
     "wof:name":"Tambla",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/203/425/421203425.geojson
+++ b/data/421/203/425/421203425.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010151,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"978537a02d6a87a4552f015e228a696e",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421203425,
-    "wof:lastmodified":1566645815,
+    "wof:lastmodified":1582319276,
     "wof:name":"Vado Ancho",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/203/451/421203451.geojson
+++ b/data/421/203/451/421203451.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010152,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"66b6de7553d980b9ed1dd4372bbac205",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421203451,
-    "wof:lastmodified":1566645823,
+    "wof:lastmodified":1582319279,
     "wof:name":"San Francisco",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/203/561/421203561.geojson
+++ b/data/421/203/561/421203561.geojson
@@ -88,6 +88,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010156,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d1605c4c4b5974d6058f60484d3838b3",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":421203561,
-    "wof:lastmodified":1566645813,
+    "wof:lastmodified":1582319274,
     "wof:name":"Danli",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/203/999/421203999.geojson
+++ b/data/421/203/999/421203999.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010170,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d2f005a9d73cf3dc81271505222df30b",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421203999,
-    "wof:lastmodified":1566645815,
+    "wof:lastmodified":1582319275,
     "wof:name":"Copan Ruinas",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/204/279/421204279.geojson
+++ b/data/421/204/279/421204279.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010179,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0bc4b09b3476d5539019c5bad2c70789",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":421204279,
-    "wof:lastmodified":1566645812,
+    "wof:lastmodified":1582319273,
     "wof:name":"La Lima",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/204/281/421204281.geojson
+++ b/data/421/204/281/421204281.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010179,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6529bb65e8c2dff2aae0fa63a6091060",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":421204281,
-    "wof:lastmodified":1566645808,
+    "wof:lastmodified":1582319271,
     "wof:name":"Valle de Angeles",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/204/589/421204589.geojson
+++ b/data/421/204/589/421204589.geojson
@@ -123,6 +123,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010191,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3949c6117e4d417e492ab6f434b97b1",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":421204589,
-    "wof:lastmodified":1566645809,
+    "wof:lastmodified":1582319272,
     "wof:name":"Olanchito",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/204/651/421204651.geojson
+++ b/data/421/204/651/421204651.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010193,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5c546d6b2497ef008f4c37f163355db5",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421204651,
-    "wof:lastmodified":1566645809,
+    "wof:lastmodified":1582319271,
     "wof:name":"Potrerillos",
     "wof:parent_id":421194673,
     "wof:placetype":"locality",

--- a/data/421/205/113/421205113.geojson
+++ b/data/421/205/113/421205113.geojson
@@ -228,6 +228,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010212,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c084c6e784c560a08538193daf30de91",
     "wof:hierarchy":[
         {
@@ -238,7 +241,7 @@
         }
     ],
     "wof:id":421205113,
-    "wof:lastmodified":1566645832,
+    "wof:lastmodified":1582319284,
     "wof:name":"Comayagua",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/205/117/421205117.geojson
+++ b/data/421/205/117/421205117.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010212,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e21100cdb799f5918242d7d8cbcb72c",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421205117,
-    "wof:lastmodified":1566645829,
+    "wof:lastmodified":1582319283,
     "wof:name":"Puerto Cortes",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/205/119/421205119.geojson
+++ b/data/421/205/119/421205119.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010212,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53cc84126975db0d544c8713885ad4b5",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421205119,
-    "wof:lastmodified":1566645829,
+    "wof:lastmodified":1582319282,
     "wof:name":"Ojojona",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/205/245/421205245.geojson
+++ b/data/421/205/245/421205245.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010216,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0d219eb09c392d4032bdb4a78f61861f",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421205245,
-    "wof:lastmodified":1566645828,
+    "wof:lastmodified":1582319282,
     "wof:name":"Orocuina",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/205/531/421205531.geojson
+++ b/data/421/205/531/421205531.geojson
@@ -113,6 +113,9 @@
     },
     "wof:country":"HN",
     "wof:created":1459010227,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab6dcaf9a1462c6335c49c80e31e65fd",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":421205531,
-    "wof:lastmodified":1566645831,
+    "wof:lastmodified":1582319283,
     "wof:name":"Lepaera",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/856/323/23/85632323.geojson
+++ b/data/856/323/23/85632323.geojson
@@ -941,6 +941,11 @@
     },
     "wof:country":"HN",
     "wof:country_alpha3":"HND",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"958d653c62c34a412008660b85462393",
     "wof:hierarchy":[
         {
@@ -955,7 +960,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644879,
+    "wof:lastmodified":1582319180,
     "wof:name":"Honduras",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/718/51/85671851.geojson
+++ b/data/856/718/51/85671851.geojson
@@ -316,6 +316,9 @@
         "wk:page":"Atl\u00e1ntida Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46ca4a72a8750f852246f8686816d8e0",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644912,
+    "wof:lastmodified":1582319205,
     "wof:name":"Atl\u00e1ntida",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/57/85671857.geojson
+++ b/data/856/718/57/85671857.geojson
@@ -303,6 +303,9 @@
         "wk:page":"Col\u00f3n Department (Honduras)"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab5b1a68421de988401d844609c41cc9",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644905,
+    "wof:lastmodified":1582319200,
     "wof:name":"Col\u00f3n",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/63/85671863.geojson
+++ b/data/856/718/63/85671863.geojson
@@ -310,6 +310,9 @@
         "wk:page":"Francisco Moraz\u00e1n Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e80c85f024fd9dbf1718ab3a7c7c19a0",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644940,
+    "wof:lastmodified":1582319223,
     "wof:name":"Francisco Moraz\u00e1n",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/69/85671869.geojson
+++ b/data/856/718/69/85671869.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Bay Islands Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f922f6f1372548e0cda1efc40a1fb4a2",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644907,
+    "wof:lastmodified":1582319202,
     "wof:name":"Islas de la Bah\u00eda",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/718/77/85671877.geojson
+++ b/data/856/718/77/85671877.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Olancho Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6bce88669bb746ce30ea1067b16679ba",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644961,
+    "wof:lastmodified":1582319237,
     "wof:name":"Olancho",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/79/85671879.geojson
+++ b/data/856/718/79/85671879.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Yoro Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e91bc7f6fb74fa97b24bb7285b71038",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644943,
+    "wof:lastmodified":1582319226,
     "wof:name":"Yoro",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/87/85671887.geojson
+++ b/data/856/718/87/85671887.geojson
@@ -260,6 +260,9 @@
         "wk:page":"Comayagua Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7b15864185b7bef6d6f1852ca8bdda9",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644933,
+    "wof:lastmodified":1582319219,
     "wof:name":"Comayagua",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/93/85671893.geojson
+++ b/data/856/718/93/85671893.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Cort\u00e9s Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5875c4aba5e6793cafaf69c67176276b",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644930,
+    "wof:lastmodified":1582319217,
     "wof:name":"Cort\u00e9s",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/99/85671899.geojson
+++ b/data/856/718/99/85671899.geojson
@@ -303,6 +303,9 @@
         "wk:page":"Intibuc\u00e1 Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4fe1389d4559013919c6ebafb17f9abd",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644936,
+    "wof:lastmodified":1582319221,
     "wof:name":"Intibuc\u00e1",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/01/85671901.geojson
+++ b/data/856/719/01/85671901.geojson
@@ -299,6 +299,9 @@
         "wk:page":"La Paz Department (Honduras)"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"60d57d9562136c78e6d9fa702c0c9507",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644893,
+    "wof:lastmodified":1582319189,
     "wof:name":"La Paz",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/05/85671905.geojson
+++ b/data/856/719/05/85671905.geojson
@@ -313,6 +313,9 @@
         "wk:page":"Santa B\u00e1rbara Department, Honduras"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd637030334f7484e5b0626abaf39d8e",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644880,
+    "wof:lastmodified":1582319181,
     "wof:name":"Santa B\u00e1rbara",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/11/85671911.geojson
+++ b/data/856/719/11/85671911.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Cop\u00e1n Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5173712f8b21ba253b9f1cde31a18717",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644881,
+    "wof:lastmodified":1582319182,
     "wof:name":"Cop\u00e1n",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/15/85671915.geojson
+++ b/data/856/719/15/85671915.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Lempira Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f1bf4254c7639d14a2e98fe7d3fb76e",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644902,
+    "wof:lastmodified":1582319196,
     "wof:name":"Lempira",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/19/85671919.geojson
+++ b/data/856/719/19/85671919.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Ocotepeque Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fef4ee7b80bdb3416f105cb413a90110",
     "wof:hierarchy":[
         {
@@ -311,7 +314,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644890,
+    "wof:lastmodified":1582319187,
     "wof:name":"Ocotepeque",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/23/85671923.geojson
+++ b/data/856/719/23/85671923.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Choluteca Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d09a0c6f6457ace145627af7ce5bb548",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644896,
+    "wof:lastmodified":1582319192,
     "wof:name":"Choluteca",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/29/85671929.geojson
+++ b/data/856/719/29/85671929.geojson
@@ -308,6 +308,9 @@
         "wk:page":"El Para\u00edso Department"
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"069a2f2fbde6e17d4822a81eb4878b88",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1566644883,
+    "wof:lastmodified":1582319184,
     "wof:name":"El Para\u00edso",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/857/938/73/85793873.geojson
+++ b/data/857/938/73/85793873.geojson
@@ -75,6 +75,9 @@
         "qs:id":222183
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"472d26d3c242a3112292e831fc210c55",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379334,
+    "wof:lastmodified":1582319176,
     "wof:name":"Buenos Aires",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/79/85793879.geojson
+++ b/data/857/938/79/85793879.geojson
@@ -105,6 +105,9 @@
         "qs_pg:id":1082613
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"49ac28121b322a5dc1e8b7cf2c4ef923",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566644878,
+    "wof:lastmodified":1582319176,
     "wof:name":"El Prado",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/83/85793883.geojson
+++ b/data/857/938/83/85793883.geojson
@@ -75,6 +75,9 @@
         "qs:id":974888
     },
     "wof:country":"HN",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ebfe4d623c2dbe1bb6d126d0fb92064",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379334,
+    "wof:lastmodified":1582319176,
     "wof:name":"El Reparto",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/414/563/890414563.geojson
+++ b/data/890/414/563/890414563.geojson
@@ -81,6 +81,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469051053,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fd3bc3d76e9889cb92a817f3f263c025",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":890414563,
-    "wof:lastmodified":1566646058,
+    "wof:lastmodified":1582319395,
     "wof:name":"Caiquin",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/890/420/201/890420201.geojson
+++ b/data/890/420/201/890420201.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469051323,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f2b9f399ad1ac8440c652c707b2d6e3",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890420201,
-    "wof:lastmodified":1566646083,
+    "wof:lastmodified":1582319399,
     "wof:name":"Santa Maria del Real",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/890/420/205/890420205.geojson
+++ b/data/890/420/205/890420205.geojson
@@ -117,6 +117,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469051323,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fce3a0bfa01bf14aaf4f6956e725b33b",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
         }
     ],
     "wof:id":890420205,
-    "wof:lastmodified":1566646080,
+    "wof:lastmodified":1582319398,
     "wof:name":"Santa Fe",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/890/420/215/890420215.geojson
+++ b/data/890/420/215/890420215.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469051324,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7731681b31b7739b2517341da51f3392",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890420215,
-    "wof:lastmodified":1566646081,
+    "wof:lastmodified":1582319399,
     "wof:name":"San Marcos de Sierra",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/890/420/217/890420217.geojson
+++ b/data/890/420/217/890420217.geojson
@@ -101,6 +101,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469051324,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"61e7188dfce1ac8e9817225579965320",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":890420217,
-    "wof:lastmodified":1566646080,
+    "wof:lastmodified":1582319398,
     "wof:name":"San Juan Guarita",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/890/420/221/890420221.geojson
+++ b/data/890/420/221/890420221.geojson
@@ -78,6 +78,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469051324,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"822a3c57f5a63f9e5de46e2743e03ac3",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890420221,
-    "wof:lastmodified":1566646079,
+    "wof:lastmodified":1582319398,
     "wof:name":"San Jose de Colinas",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/890/421/511/890421511.geojson
+++ b/data/890/421/511/890421511.geojson
@@ -85,6 +85,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469051395,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"42690c201013914967742461cf288396",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":890421511,
-    "wof:lastmodified":1566646071,
+    "wof:lastmodified":1582319397,
     "wof:name":"Concepcion de Maria",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/890/429/335/890429335.geojson
+++ b/data/890/429/335/890429335.geojson
@@ -182,6 +182,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469051810,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6868fb640a5934b979eb4f072f851eaa",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":890429335,
-    "wof:lastmodified":1566646077,
+    "wof:lastmodified":1582319397,
     "wof:name":"Nueva Ocotepeque",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/890/429/347/890429347.geojson
+++ b/data/890/429/347/890429347.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469051811,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"202f386c9697b90db98ad12526dcb9c3",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890429347,
-    "wof:lastmodified":1566646076,
+    "wof:lastmodified":1582319397,
     "wof:name":"La Encarnacion",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/890/429/359/890429359.geojson
+++ b/data/890/429/359/890429359.geojson
@@ -631,6 +631,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469051811,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2d636564dc4bcc465629c567eb1b9e88",
     "wof:hierarchy":[
         {
@@ -642,7 +645,7 @@
         }
     ],
     "wof:id":890429359,
-    "wof:lastmodified":1566646076,
+    "wof:lastmodified":1582319397,
     "wof:name":"Buenos Aires",
     "wof:parent_id":421170709,
     "wof:placetype":"locality",

--- a/data/890/438/351/890438351.geojson
+++ b/data/890/438/351/890438351.geojson
@@ -44,6 +44,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469052190,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5638fd1e9544b631c63c93151529effb",
     "wof:hierarchy":[
         {
@@ -55,7 +58,7 @@
         }
     ],
     "wof:id":890438351,
-    "wof:lastmodified":1566646068,
+    "wof:lastmodified":1582319396,
     "wof:name":"Casa Quemada",
     "wof:parent_id":421182937,
     "wof:placetype":"locality",

--- a/data/890/442/111/890442111.geojson
+++ b/data/890/442/111/890442111.geojson
@@ -286,6 +286,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469052350,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c93719733a7f6b71636e77facd3db0f1",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         }
     ],
     "wof:id":890442111,
-    "wof:lastmodified":1566646084,
+    "wof:lastmodified":1582319399,
     "wof:name":"Comayagua",
     "wof:parent_id":421205113,
     "wof:placetype":"locality",

--- a/data/890/455/339/890455339.geojson
+++ b/data/890/455/339/890455339.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469052943,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c53d27cf4a86342fc350d59ce657f58",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890455339,
-    "wof:lastmodified":1566646065,
+    "wof:lastmodified":1582319396,
     "wof:name":"Quimistan",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/890/455/353/890455353.geojson
+++ b/data/890/455/353/890455353.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"HN",
     "wof:created":1469052943,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"abca2a9059946624b42bd1f6af29cb36",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":890455353,
-    "wof:lastmodified":1566646063,
+    "wof:lastmodified":1582319395,
     "wof:name":"Moroceli",
     "wof:parent_id":85671929,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.