### PR TITLE
Name updates

### DIFF
--- a/data/421/182/511/421182511.geojson
+++ b/data/421/182/511/421182511.geojson
@@ -135,7 +135,7 @@
         "\u062f\u0627\u0646\u0644\u06cc \u060c \u0627\u0644 \u067e\u0627\u0631\u0627\u06cc\u0633\u0648"
     ],
     "name:urd_x_variant":[
-        "\u062f\u0627\u0646\u0644\u06cc "
+        "\u062f\u0627\u0646\u0644\u06cc"
     ],
     "name:vie_x_preferred":[
         "Danli"
@@ -170,8 +170,8 @@
     "wof:belongsto":[
         102191575,
         85632323,
-        85671929,
-        421203561
+        421203561,
+        85671929
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -194,7 +194,7 @@
         }
     ],
     "wof:id":421182511,
-    "wof:lastmodified":1566646026,
+    "wof:lastmodified":1587163137,
     "wof:name":"Danl\u00ed",
     "wof:parent_id":421203561,
     "wof:placetype":"locality",

--- a/data/421/201/747/421201747.geojson
+++ b/data/421/201/747/421201747.geojson
@@ -27,7 +27,7 @@
         "\u09a4\u09cb\u0995\u09c1\u09af\u09bc\u09be"
     ],
     "name:ben_x_variant":[
-        "\u09a4\u09cb\u0995\u09c1\u09af\u09bc\u09be "
+        "\u09a4\u09cb\u0995\u09c1\u09af\u09bc\u09be"
     ],
     "name:bul_x_preferred":[
         "\u0422\u043e\u043a\u043e\u0430"
@@ -132,7 +132,7 @@
         "\u062a\u0648\u06a9\u0648\u0627 \u060c \u06a9\u0648\u0644\u0646"
     ],
     "name:urd_x_variant":[
-        "\u062a\u0648\u06a9\u0648\u0627 "
+        "\u062a\u0648\u06a9\u0648\u0627"
     ],
     "name:vie_x_preferred":[
         "Tocoa"
@@ -167,8 +167,8 @@
     "wof:belongsto":[
         102191575,
         85632323,
-        85671857,
-        421182985
+        421182985,
+        85671857
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -191,7 +191,7 @@
         }
     ],
     "wof:id":421201747,
-    "wof:lastmodified":1566645956,
+    "wof:lastmodified":1587163137,
     "wof:name":"Tocoa",
     "wof:parent_id":421182985,
     "wof:placetype":"locality",

--- a/data/856/323/23/85632323.geojson
+++ b/data/856/323/23/85632323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.421985,
-    "geom:area_square_m":112620818867.553406,
+    "geom:area_square_m":112620818859.810135,
     "geom:bbox":"-89.355961,12.984225,-82.389137,17.418722",
     "geom:latitude":14.82234,
     "geom:longitude":-86.615837,
@@ -54,6 +54,9 @@
     ],
     "name:arg_x_variant":[
         "Onduras"
+    ],
+    "name:ary_x_preferred":[
+        "\u0647\u0648\u0646\u062f\u0648\u0631\u0627\u0633"
     ],
     "name:arz_x_preferred":[
         "\u0647\u0648\u0646\u062f\u0648\u0631\u0627\u0633"
@@ -142,6 +145,9 @@
     "name:chu_x_preferred":[
         "\u041e\u043d\u0434\u043e\u0443\u0440\u0430\u0441\u044a"
     ],
+    "name:chy_x_preferred":[
+        "Honduras"
+    ],
     "name:ckb_x_preferred":[
         "\u06be\u06c6\u0646\u062f\u0648\u0648\u0631\u0627\u0633"
     ],
@@ -155,6 +161,12 @@
         "Hondwras"
     ],
     "name:dan_x_preferred":[
+        "Honduras"
+    ],
+    "name:deu_at_x_preferred":[
+        "Honduras"
+    ],
+    "name:deu_ch_x_preferred":[
         "Honduras"
     ],
     "name:deu_x_preferred":[
@@ -174,6 +186,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039f\u03bd\u03b4\u03bf\u03cd\u03c1\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Honduras"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Honduras"
     ],
     "name:eng_x_preferred":[
         "Honduras"
@@ -234,6 +252,9 @@
     ],
     "name:gag_x_preferred":[
         "Honduras"
+    ],
+    "name:gcr_x_preferred":[
+        "Ondiras"
     ],
     "name:ger_x_variant":[
         "Republik Honduras"
@@ -567,6 +588,9 @@
     "name:pol_x_preferred":[
         "Honduras"
     ],
+    "name:por_br_x_preferred":[
+        "Honduras"
+    ],
     "name:por_x_preferred":[
         "Honduras"
     ],
@@ -606,6 +630,9 @@
     "name:san_x_preferred":[
         "\u0939\u093e\u0902\u0921\u0942\u0930\u0938"
     ],
+    "name:sat_x_preferred":[
+        "\u1c66\u1c73\u1c71\u1c70\u1c69\u1c68\u1c5f\u1c65"
+    ],
     "name:scn_x_preferred":[
         "Honduras"
     ],
@@ -630,11 +657,17 @@
     "name:sme_x_preferred":[
         "Honduras"
     ],
+    "name:smn_x_preferred":[
+        "Honduras"
+    ],
     "name:smo_x_preferred":[
         "Honilagi"
     ],
     "name:sna_x_preferred":[
         "Honduras"
+    ],
+    "name:snd_x_preferred":[
+        "\u0647\u0646\u068a\u0648\u0631\u0627\u0633"
     ],
     "name:som_x_preferred":[
         "Honduras"
@@ -650,6 +683,12 @@
         "Hondurasi"
     ],
     "name:srd_x_preferred":[
+        "Honduras"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u0425\u043e\u043d\u0434\u0443\u0440\u0430\u0441"
+    ],
+    "name:srp_el_x_preferred":[
         "Honduras"
     ],
     "name:srp_x_preferred":[
@@ -673,6 +712,9 @@
     "name:szl_x_preferred":[
         "H\u016fnduras"
     ],
+    "name:szy_x_preferred":[
+        "Honduras"
+    ],
     "name:tah_x_preferred":[
         "Honoturati"
     ],
@@ -684,6 +726,9 @@
     ],
     "name:tat_x_preferred":[
         "\u0413\u043e\u043d\u0434\u0443\u0440\u0430\u0441"
+    ],
+    "name:tat_x_variant":[
+        "\u04ba\u043e\u043d\u0434\u0443\u0440\u0430\u0441"
     ],
     "name:tel_x_preferred":[
         "\u0c39\u0c4b\u0c02\u0c21\u0c41\u0c30\u0c3e\u0c38\u0c4d"
@@ -717,6 +762,9 @@
     ],
     "name:tur_x_preferred":[
         "Honduras"
+    ],
+    "name:udm_x_preferred":[
+        "\u0413\u043e\u043d\u0434\u0443\u0440\u0430\u0441"
     ],
     "name:uig_x_preferred":[
         "\u06be\u0648\u0646\u062f\u06c7\u0631\u0627\u0633"
@@ -794,8 +842,26 @@
     "name:zha_x_preferred":[
         "Honduras"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u6d2a\u90fd\u62c9\u65af"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u6d2a\u90fd\u62c9\u65af"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Honduras"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u6d2a\u90fd\u62c9\u65af"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u6d2a\u90fd\u62c9\u65af"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u6d2a\u90fd\u62c9\u65af"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5b8f\u90fd\u62c9\u65af"
     ],
     "name:zho_x_preferred":[
         "\u6d2a\u90fd\u62c9\u65af"
@@ -961,7 +1027,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1583797347,
+    "wof:lastmodified":1587427673,
     "wof:name":"Honduras",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.