### PR TITLE
Standardize on unknown source

### DIFF
--- a/data/102/556/409/102556409.geojson
+++ b/data/102/556/409/102556409.geojson
@@ -18,7 +18,7 @@
         "VTA",
         "KVTA"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424841,
@@ -37,7 +37,7 @@
         "icao:code":"KVTA"
     },
     "wof:country":"HN",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102556409,
@@ -46,7 +46,7 @@
         }
     ],
     "wof:id":102556409,
-    "wof:lastmodified":1566644712,
+    "wof:lastmodified":1589218812,
     "wof:name":"Victoria Airport",
     "wof:parent_id":85671879,
     "wof:placetype":"campus",
@@ -63,5 +63,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst/whosonfirst-sources/issues/112.

Swaps any "missing" values in `src:geom` properties to "unknown". I also checked values in `src:geom_alt` and `wof:geom_alt` properties, but there were no cases.

No PIP required, can merge once approved.