### PR TITLE
Update megacity records

### DIFF
--- a/data/421/173/057/421173057.geojson
+++ b/data/421/173/057/421173057.geojson
@@ -558,6 +558,7 @@
     "wof:concordances":{
         "gn:id":3600949,
         "gp:id":107681,
+        "ne:id":1159150583,
         "qs_pg:id":489209,
         "wd:id":"Q3238",
         "wk:page":"Tegucigalpa"
@@ -578,7 +579,8 @@
         }
     ],
     "wof:id":421173057,
-    "wof:lastmodified":1607390902,
+    "wof:lastmodified":1608688176,
+    "wof:megacity":1,
     "wof:name":"Tegucigalpa",
     "wof:parent_id":1108701727,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary