### PR TITLE
hn concordances, placetype local, and more

### DIFF
--- a/data/110/870/164/9/1108701649.geojson
+++ b/data/110/870/164/9/1108701649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02478,
-    "geom:area_square_m":294719775.298131,
+    "geom:area_square_m":294719850.459925,
     "geom:bbox":"-84.999863,15.780781,-84.792206,15.98161",
     "geom:latitude":15.873288,
     "geom:longitude":-84.916864,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"HN.GD.JF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504309,
-    "wof:geomhash":"9b6eae69da12890345d9b8aa44fa4a94",
+    "wof:geomhash":"d83966fad136ff0345b36cc064a5d2bd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108701649,
-    "wof:lastmodified":1627522172,
+    "wof:lastmodified":1695886640,
     "wof:name":"Batalla",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/110/870/165/1/1108701651.geojson
+++ b/data/110/870/165/1/1108701651.geojson
@@ -119,6 +119,7 @@
     "wof:concordances":{
         "hasc:id":"HN.GD.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504312,
     "wof:geomhash":"b2421d1c4dbea783d9912b09521db38c",
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108701651,
-    "wof:lastmodified":1694492926,
+    "wof:lastmodified":1695886665,
     "wof:name":"Belen",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/110/870/165/1/1108701651.geojson
+++ b/data/110/870/165/1/1108701651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000132,
-    "geom:area_square_m":1566309.18827,
+    "geom:area_square_m":1566277.174597,
     "geom:bbox":"-84.792892,15.88288,-84.756554,15.903126",
     "geom:latitude":15.893467,
     "geom:longitude":-84.769761,
@@ -47,6 +47,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03b5\u03bb\u03ad\u03bd"
+    ],
+    "name:eng_x_preferred":[
+        "Belen"
     ],
     "name:eng_x_variant":[
         "Brus Laguna"
@@ -118,7 +121,7 @@
     },
     "wof:country":"HN",
     "wof:created":1474504312,
-    "wof:geomhash":"6721d96dca6d599480afb5d539bdb8e8",
+    "wof:geomhash":"b2421d1c4dbea783d9912b09521db38c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":1108701651,
-    "wof:lastmodified":1636495827,
+    "wof:lastmodified":1694492926,
     "wof:name":"Belen",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/110/870/165/3/1108701653.geojson
+++ b/data/110/870/165/3/1108701653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012985,
-    "geom:area_square_m":155801160.551414,
+    "geom:area_square_m":155801185.307497,
     "geom:bbox":"-88.079903,13.90227,-87.94696,14.089993",
     "geom:latitude":13.990866,
     "geom:longitude":-88.018296,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"HN.LP.CB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504321,
-    "wof:geomhash":"11b64ae33882b7d42d6e17f1b71cfc05",
+    "wof:geomhash":"ed89c4c77878ed283c61d4d767a837fe",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108701653,
-    "wof:lastmodified":1627522173,
+    "wof:lastmodified":1695886641,
     "wof:name":"Cabanas",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/110/870/165/5/1108701655.geojson
+++ b/data/110/870/165/5/1108701655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005438,
-    "geom:area_square_m":65002678.352444,
+    "geom:area_square_m":65002802.211782,
     "geom:bbox":"-88.198082,14.765628,-88.091377,14.878205",
     "geom:latitude":14.82296,
     "geom:longitude":-88.148953,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"HN.SB.CS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504350,
-    "wof:geomhash":"4a2658c17ea582ef491f4421241c82d5",
+    "wof:geomhash":"beccd8744abfdf9edfa54143e0bb9c31",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108701655,
-    "wof:lastmodified":1627522174,
+    "wof:lastmodified":1695886643,
     "wof:name":"Concepcion del Sur",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/110/870/165/9/1108701659.geojson
+++ b/data/110/870/165/9/1108701659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007709,
-    "geom:area_square_m":92466891.822554,
+    "geom:area_square_m":92466827.778551,
     "geom:bbox":"-88.377029,13.992594,-88.262558,14.107163",
     "geom:latitude":14.048736,
     "geom:longitude":-88.318768,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"HN.IN.CN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504355,
-    "wof:geomhash":"2137fdfc13474ead6fb334f6c8da8b22",
+    "wof:geomhash":"7162c9e37e93cbb9f9986699201b9bdb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108701659,
-    "wof:lastmodified":1627522173,
+    "wof:lastmodified":1695886642,
     "wof:name":"Concepcion",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/110/870/166/1/1108701661.geojson
+++ b/data/110/870/166/1/1108701661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013627,
-    "geom:area_square_m":163404704.297817,
+    "geom:area_square_m":163404538.604519,
     "geom:bbox":"-88.663681,14.06881,-88.479836,14.205453",
     "geom:latitude":14.127404,
     "geom:longitude":-88.570507,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"HN.LE.GC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504360,
-    "wof:geomhash":"06607f618d89649e8eaeb2f64417ca2c",
+    "wof:geomhash":"ed85d4315564e41189cd298cbfd65232",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108701661,
-    "wof:lastmodified":1627522174,
+    "wof:lastmodified":1695886643,
     "wof:name":"Congolon",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/110/870/166/3/1108701663.geojson
+++ b/data/110/870/166/3/1108701663.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"HN.CH.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504364,
     "wof:geomhash":"c4cb7fa786f90e8797999505a20ef077",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108701663,
-    "wof:lastmodified":1694492839,
+    "wof:lastmodified":1695886278,
     "wof:name":"Coraycito",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/110/870/166/3/1108701663.geojson
+++ b/data/110/870/166/3/1108701663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005293,
-    "geom:area_square_m":63584482.703134,
+    "geom:area_square_m":63584503.116788,
     "geom:bbox":"-87.464615,13.671185,-87.360977,13.759345",
     "geom:latitude":13.717054,
     "geom:longitude":-87.422605,
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:eng_x_preferred":[
+        "Coraycito"
+    ],
     "name:eng_x_variant":[
         "San Jose",
         "San Jos\u00e9"
@@ -53,7 +56,7 @@
     },
     "wof:country":"HN",
     "wof:created":1474504364,
-    "wof:geomhash":"1052792b7fd76e016b248afbdcb74f48",
+    "wof:geomhash":"c4cb7fa786f90e8797999505a20ef077",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":1108701663,
-    "wof:lastmodified":1628266640,
+    "wof:lastmodified":1694492839,
     "wof:name":"Coraycito",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/110/870/166/5/1108701665.geojson
+++ b/data/110/870/166/5/1108701665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006841,
-    "geom:area_square_m":81980092.235479,
+    "geom:area_square_m":81980144.482574,
     "geom:bbox":"-88.425041,14.225562,-88.295082,14.297004",
     "geom:latitude":14.262368,
     "geom:longitude":-88.357859,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"HN.IN.DO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504375,
-    "wof:geomhash":"b72f8d8e8407221bac91fdaafb38903e",
+    "wof:geomhash":"e99b65908b38376f61b92e55d18384bd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108701665,
-    "wof:lastmodified":1636495826,
+    "wof:lastmodified":1695886664,
     "wof:name":"Dolores",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/110/870/166/7/1108701667.geojson
+++ b/data/110/870/166/7/1108701667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029802,
-    "geom:area_square_m":357784586.484726,
+    "geom:area_square_m":357784859.840005,
     "geom:bbox":"-86.683029,13.758092,-86.377945,13.94207",
     "geom:latitude":13.851715,
     "geom:longitude":-86.525933,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"HN.EP.EP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504388,
-    "wof:geomhash":"7d8cea9b1581283f667cbb654a4a92cc",
+    "wof:geomhash":"bb61b9f49b64714c07bdd99898278670",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108701667,
-    "wof:lastmodified":1627522176,
+    "wof:lastmodified":1695886647,
     "wof:name":"El Paraiso",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/110/870/166/9/1108701669.geojson
+++ b/data/110/870/166/9/1108701669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034914,
-    "geom:area_square_m":417574130.869045,
+    "geom:area_square_m":417574551.934627,
     "geom:bbox":"-87.339119,14.558929,-87.097366,14.861129",
     "geom:latitude":14.708178,
     "geom:longitude":-87.221999,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"HN.FM.EP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504391,
-    "wof:geomhash":"3c46ceadf914018ccc86808a25d6fcea",
+    "wof:geomhash":"597fa55fa15d6c0de5c42fa933835ff5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108701669,
-    "wof:lastmodified":1636495825,
+    "wof:lastmodified":1695886662,
     "wof:name":"El Porvenir",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/110/870/167/1/1108701671.geojson
+++ b/data/110/870/167/1/1108701671.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"HN.CM.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504399,
     "wof:geomhash":"2a0cf6ab3daeea5d3f7a949bc5edeb16",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108701671,
-    "wof:lastmodified":1694492843,
+    "wof:lastmodified":1695886289,
     "wof:name":"El Volcan",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/110/870/167/1/1108701671.geojson
+++ b/data/110/870/167/1/1108701671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00591,
-    "geom:area_square_m":70604684.288484,
+    "geom:area_square_m":70604592.324673,
     "geom:bbox":"-88.96347,14.908907,-88.818161,15.000499",
     "geom:latitude":14.960747,
     "geom:longitude":-88.899645,
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:eng_x_preferred":[
+        "El Volcan"
+    ],
     "name:eng_x_variant":[
         "San Jeronimo",
         "San Jer\u00f3nimo"
@@ -53,7 +56,7 @@
     },
     "wof:country":"HN",
     "wof:created":1474504399,
-    "wof:geomhash":"48929d7fcd4031e5c6e8e6025ea4b864",
+    "wof:geomhash":"2a0cf6ab3daeea5d3f7a949bc5edeb16",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":1108701671,
-    "wof:lastmodified":1628266647,
+    "wof:lastmodified":1694492843,
     "wof:name":"El Volcan",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/110/870/167/3/1108701673.geojson
+++ b/data/110/870/167/3/1108701673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.218557,
-    "geom:area_square_m":2615914300.456872,
+    "geom:area_square_m":2615914467.011434,
     "geom:bbox":"-86.677689,14.271442,-85.940865,14.792964",
     "geom:latitude":14.541983,
     "geom:longitude":-86.315249,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"HN.OL.JU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504445,
-    "wof:geomhash":"ce402dab93f9e034292ddd0512cde113",
+    "wof:geomhash":"a2f643271843228f584089f40e649b6e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108701673,
-    "wof:lastmodified":1627522178,
+    "wof:lastmodified":1695886651,
     "wof:name":"Jutiquile",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/110/870/167/7/1108701677.geojson
+++ b/data/110/870/167/7/1108701677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012406,
-    "geom:area_square_m":148111561.758632,
+    "geom:area_square_m":148111561.757907,
     "geom:bbox":"-88.7808074951,15.0143280029,-88.6367797852,15.2015275955",
     "geom:latitude":15.090324,
     "geom:longitude":-88.705245,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"HN.CP.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504452,
-    "wof:geomhash":"198340725f5fb989aa62f124f3bfb5dc",
+    "wof:geomhash":"f4d3f0b445c9dba8bf6692474020f74c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108701677,
-    "wof:lastmodified":1566645550,
+    "wof:lastmodified":1695886360,
     "wof:name":"La Entrada",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/110/870/167/9/1108701679.geojson
+++ b/data/110/870/167/9/1108701679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004422,
-    "geom:area_square_m":53006120.916522,
+    "geom:area_square_m":53006015.669203,
     "geom:bbox":"-87.833488,14.163226,-87.728691,14.24363",
     "geom:latitude":14.207485,
     "geom:longitude":-87.779158,
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:eng_x_preferred":[
+        "La Penita"
+    ],
     "name:eng_x_variant":[
         "San Sebastian",
         "San Sebasti\u00e1n"
@@ -53,7 +56,7 @@
     },
     "wof:country":"HN",
     "wof:created":1474504464,
-    "wof:geomhash":"beed2efb2b0a43dd373905147fddbca7",
+    "wof:geomhash":"94ba31dc91881cfb1be9d9c76084a7fc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":1108701679,
-    "wof:lastmodified":1628266670,
+    "wof:lastmodified":1694492858,
     "wof:name":"La Penita",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/110/870/167/9/1108701679.geojson
+++ b/data/110/870/167/9/1108701679.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"HN.CM.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504464,
     "wof:geomhash":"94ba31dc91881cfb1be9d9c76084a7fc",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108701679,
-    "wof:lastmodified":1694492858,
+    "wof:lastmodified":1695886326,
     "wof:name":"La Penita",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/110/870/168/1/1108701681.geojson
+++ b/data/110/870/168/1/1108701681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05203,
-    "geom:area_square_m":621155634.956184,
+    "geom:area_square_m":621155762.093166,
     "geom:bbox":"-86.792427,14.926257,-86.55294,15.296028",
     "geom:latitude":15.097168,
     "geom:longitude":-86.683314,
@@ -169,9 +169,10 @@
     "wof:concordances":{
         "hasc:id":"HN.OL.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504471,
-    "wof:geomhash":"0b4a3717198520b2eb8e33c516a2658c",
+    "wof:geomhash":"144ded2823f40672f9ff7f7aa3e6dcad",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":1108701681,
-    "wof:lastmodified":1636495824,
+    "wof:lastmodified":1695886661,
     "wof:name":"La Union",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/110/870/168/3/1108701683.geojson
+++ b/data/110/870/168/3/1108701683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007938,
-    "geom:area_square_m":95099459.439802,
+    "geom:area_square_m":95099432.511712,
     "geom:bbox":"-89.086449,14.225257,-88.946915,14.39447",
     "geom:latitude":14.31952,
     "geom:longitude":-89.011691,
@@ -177,9 +177,10 @@
     "wof:concordances":{
         "hasc:id":"HN.OC.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504504,
-    "wof:geomhash":"2641f8421e42f09a7a8ff1f57a04e1ac",
+    "wof:geomhash":"1131c3580da4c84c1f74279cab72d4ac",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":1108701683,
-    "wof:lastmodified":1636495825,
+    "wof:lastmodified":1695886663,
     "wof:name":"Mercedes",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/110/870/168/5/1108701685.geojson
+++ b/data/110/870/168/5/1108701685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024264,
-    "geom:area_square_m":290422812.581437,
+    "geom:area_square_m":290422812.581769,
     "geom:bbox":"-88.374961853,14.3877391815,-88.1837463379,14.6534547806",
     "geom:latitude":14.534133,
     "geom:longitude":-88.284453,
@@ -37,6 +37,9 @@
         "Monte Verde"
     ],
     "name:deu_x_preferred":[
+        "Monte Verde"
+    ],
+    "name:eng_x_preferred":[
         "Monte Verde"
     ],
     "name:eng_x_variant":[
@@ -101,7 +104,7 @@
     },
     "wof:country":"HN",
     "wof:created":1474504509,
-    "wof:geomhash":"e5d18b27db41caf9c3dd761a0c07e0fa",
+    "wof:geomhash":"4de59b1537e801d7bf66e31190c5e4cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":1108701685,
-    "wof:lastmodified":1566645545,
+    "wof:lastmodified":1694492404,
     "wof:name":"Monte Verde",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/110/870/168/5/1108701685.geojson
+++ b/data/110/870/168/5/1108701685.geojson
@@ -102,6 +102,7 @@
     "wof:concordances":{
         "hasc:id":"HN.IN.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504509,
     "wof:geomhash":"4de59b1537e801d7bf66e31190c5e4cf",
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108701685,
-    "wof:lastmodified":1694492404,
+    "wof:lastmodified":1695886359,
     "wof:name":"Monte Verde",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/110/870/168/7/1108701687.geojson
+++ b/data/110/870/168/7/1108701687.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"HN.IN.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504523,
     "wof:geomhash":"2674203e4616a8b9ef8308c577d19e6a",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108701687,
-    "wof:lastmodified":1694492871,
+    "wof:lastmodified":1695886363,
     "wof:name":"Nueva Esperanza",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/110/870/168/7/1108701687.geojson
+++ b/data/110/870/168/7/1108701687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001264,
-    "geom:area_square_m":15117413.283799,
+    "geom:area_square_m":15117365.9146,
     "geom:bbox":"-88.255066,14.621467,-88.191872,14.656629",
     "geom:latitude":14.64118,
     "geom:longitude":-88.225632,
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:eng_x_preferred":[
+        "Nueva Esperanza"
+    ],
     "name:eng_x_variant":[
         "Yamaranguila",
         "San Francisco de Opalaca"
@@ -53,7 +56,7 @@
     },
     "wof:country":"HN",
     "wof:created":1474504523,
-    "wof:geomhash":"a72bf7202cbff88f437ad9f88525cff7",
+    "wof:geomhash":"2674203e4616a8b9ef8308c577d19e6a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":1108701687,
-    "wof:lastmodified":1628266693,
+    "wof:lastmodified":1694492871,
     "wof:name":"Nueva Esperanza",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/110/870/168/9/1108701689.geojson
+++ b/data/110/870/168/9/1108701689.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"HN.GD.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504525,
     "wof:geomhash":"a621942cde838db4df9a8203db939217",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108701689,
-    "wof:lastmodified":1694492871,
+    "wof:lastmodified":1695886363,
     "wof:name":"Nueva Jerusalen",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/110/870/168/9/1108701689.geojson
+++ b/data/110/870/168/9/1108701689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000134,
-    "geom:area_square_m":1597579.402791,
+    "geom:area_square_m":1597596.953994,
     "geom:bbox":"-84.757843,15.880401,-84.737053,15.89178",
     "geom:latitude":15.88569,
     "geom:longitude":-84.748318,
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:eng_x_preferred":[
+        "Nueva Jerusalen"
+    ],
     "name:eng_x_variant":[
         "Brus Laguna"
     ],
@@ -52,7 +55,7 @@
     },
     "wof:country":"HN",
     "wof:created":1474504525,
-    "wof:geomhash":"c05b380c636079c17add33a3e2b30178",
+    "wof:geomhash":"a621942cde838db4df9a8203db939217",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":1108701689,
-    "wof:lastmodified":1628266693,
+    "wof:lastmodified":1694492871,
     "wof:name":"Nueva Jerusalen",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/110/870/169/1/1108701691.geojson
+++ b/data/110/870/169/1/1108701691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010923,
-    "geom:area_square_m":131026484.843207,
+    "geom:area_square_m":131026484.843341,
     "geom:bbox":"-86.8364486694,13.977766037,-86.7049713135,14.138051033",
     "geom:latitude":14.054075,
     "geom:longitude":-86.75646,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"HN.EP.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504545,
-    "wof:geomhash":"75c5382dd1bb4d2fbfcb00c7431333c7",
+    "wof:geomhash":"1534d7319cc4f2956e55e8326f4bfae6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108701691,
-    "wof:lastmodified":1566645556,
+    "wof:lastmodified":1695886362,
     "wof:name":"Potrerillos",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/110/870/169/5/1108701695.geojson
+++ b/data/110/870/169/5/1108701695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045697,
-    "geom:area_square_m":545565358.744251,
+    "geom:area_square_m":545565551.424283,
     "geom:bbox":"-83.525887,14.976615,-83.149658,15.249168",
     "geom:latitude":15.089982,
     "geom:longitude":-83.391402,
@@ -91,9 +91,10 @@
     "wof:concordances":{
         "hasc:id":"HN.GD.RV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504560,
-    "wof:geomhash":"e8e200e4364fc17c505b4a248ac1a62a",
+    "wof:geomhash":"61e8f638b304a84e04aa92c4393677d5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108701695,
-    "wof:lastmodified":1627522180,
+    "wof:lastmodified":1695886656,
     "wof:name":"Raya",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/110/870/169/7/1108701697.geojson
+++ b/data/110/870/169/7/1108701697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031253,
-    "geom:area_square_m":372431979.21305,
+    "geom:area_square_m":372431979.212766,
     "geom:bbox":"-86.3067474365,15.3670406342,-86.0297698975,15.5952959061",
     "geom:latitude":15.478922,
     "geom:longitude":-86.170233,
@@ -259,9 +259,10 @@
     "wof:concordances":{
         "hasc:id":"HN.CL.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504567,
-    "wof:geomhash":"ffa23824a4eda814f9994b1bc3c3fdc8",
+    "wof:geomhash":"9f12431850c013714d307f67e4dd6bc4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -271,7 +272,7 @@
         }
     ],
     "wof:id":1108701697,
-    "wof:lastmodified":1566645554,
+    "wof:lastmodified":1695886361,
     "wof:name":"Saba",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/110/870/169/9/1108701699.geojson
+++ b/data/110/870/169/9/1108701699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012223,
-    "geom:area_square_m":146832377.572196,
+    "geom:area_square_m":146832278.249766,
     "geom:bbox":"-86.925224,13.647285,-86.759575,13.773677",
     "geom:latitude":13.715353,
     "geom:longitude":-86.839437,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"HN.EP.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504579,
-    "wof:geomhash":"0e0e99423e15f454fde93ac2fe316d02",
+    "wof:geomhash":"01249140edbcdf6d1ebd0f382549c75b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108701699,
-    "wof:lastmodified":1627522181,
+    "wof:lastmodified":1695886658,
     "wof:name":"San Antonio de Flores",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/110/870/170/1/1108701701.geojson
+++ b/data/110/870/170/1/1108701701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007568,
-    "geom:area_square_m":90816912.384034,
+    "geom:area_square_m":90816900.213922,
     "geom:bbox":"-88.511375,13.860766,-88.413536,14.019309",
     "geom:latitude":13.942098,
     "geom:longitude":-88.466255,
@@ -100,9 +100,10 @@
         "hasc:id":"HN.IN.SA",
         "wd:id":"Q1645362"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504584,
-    "wof:geomhash":"256f5ff39b04639fd22f5a8fea78a8c6",
+    "wof:geomhash":"60ab34d6f3aad6f005d32d686837defa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108701701,
-    "wof:lastmodified":1690930226,
+    "wof:lastmodified":1695886669,
     "wof:name":"San Antonio",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/110/870/170/3/1108701703.geojson
+++ b/data/110/870/170/3/1108701703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013144,
-    "geom:area_square_m":156788506.048462,
+    "geom:area_square_m":156788271.890559,
     "geom:bbox":"-88.75824,15.213181,-88.577019,15.34045",
     "geom:latitude":15.2718,
     "geom:longitude":-88.668126,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"HN.SB.NF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504608,
-    "wof:geomhash":"5a61f1a5c8a6e7113ec217f4fa7883f4",
+    "wof:geomhash":"a3dbe45d76d24ba475fb3e678a4f5571",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108701703,
-    "wof:lastmodified":1627522183,
+    "wof:lastmodified":1695886660,
     "wof:name":"San Jose de Tarros",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/110/870/170/5/1108701705.geojson
+++ b/data/110/870/170/5/1108701705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005516,
-    "geom:area_square_m":66110359.141939,
+    "geom:area_square_m":66110614.590397,
     "geom:bbox":"-88.012482,14.197837,-87.887939,14.273454",
     "geom:latitude":14.232229,
     "geom:longitude":-87.955323,
@@ -103,9 +103,10 @@
     "wof:concordances":{
         "hasc:id":"HN.LP.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504614,
-    "wof:geomhash":"87d80e286a47c811d042c0e7a1c55b2f",
+    "wof:geomhash":"b17f19806a1ffc3065721c215708b751",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108701705,
-    "wof:lastmodified":1636495829,
+    "wof:lastmodified":1695886670,
     "wof:name":"San Jose",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/110/870/170/7/1108701707.geojson
+++ b/data/110/870/170/7/1108701707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014089,
-    "geom:area_square_m":169444411.493268,
+    "geom:area_square_m":169444433.249027,
     "geom:bbox":"-87.49781,13.357687,-87.340858,13.526731",
     "geom:latitude":13.444335,
     "geom:longitude":-87.414422,
@@ -180,9 +180,10 @@
     "wof:concordances":{
         "hasc:id":"HN.VA.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504620,
-    "wof:geomhash":"1c51d3e2ebc0654cda175fc961f376e7",
+    "wof:geomhash":"3ea1583b357b75fd55e65175d6478b95",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":1108701707,
-    "wof:lastmodified":1636495828,
+    "wof:lastmodified":1695886666,
     "wof:name":"San Lorenzo",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/110/870/170/9/1108701709.geojson
+++ b/data/110/870/170/9/1108701709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018504,
-    "geom:area_square_m":220729215.441105,
+    "geom:area_square_m":220729290.400114,
     "geom:bbox":"-88.51664,15.186496,-88.303871,15.331623",
     "geom:latitude":15.262982,
     "geom:longitude":-88.403158,
@@ -144,9 +144,10 @@
     "wof:concordances":{
         "hasc:id":"HN.SB.SM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504633,
-    "wof:geomhash":"f33364e6101d3b4506745c1ffa469501",
+    "wof:geomhash":"1d88a05722e89d5e8b2e5f4db12512fa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1108701709,
-    "wof:lastmodified":1636495827,
+    "wof:lastmodified":1695886665,
     "wof:name":"San Marcos",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/110/870/171/3/1108701713.geojson
+++ b/data/110/870/171/3/1108701713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008536,
-    "geom:area_square_m":101999585.47979,
+    "geom:area_square_m":101999312.081167,
     "geom:bbox":"-88.461487,14.834761,-88.257896,14.971063",
     "geom:latitude":14.910876,
     "geom:longitude":-88.376354,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"HN.SB.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504644,
-    "wof:geomhash":"ec05d5b0c5be477cca002c259c31d9da",
+    "wof:geomhash":"d43ad2aab31ea48e4f782eab5ca36009",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108701713,
-    "wof:lastmodified":1627522184,
+    "wof:lastmodified":1695886662,
     "wof:name":"San Nicolas",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/110/870/171/5/1108701715.geojson
+++ b/data/110/870/171/5/1108701715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008516,
-    "geom:area_square_m":101846806.724447,
+    "geom:area_square_m":101846397.936635,
     "geom:bbox":"-88.452888,14.653455,-88.317314,14.769844",
     "geom:latitude":14.709513,
     "geom:longitude":-88.379914,
@@ -130,9 +130,10 @@
         "hasc:id":"HN.LE.SR",
         "wd:id":"Q964647"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504650,
-    "wof:geomhash":"c97ebcd5c52e6062af27ac556f07759d",
+    "wof:geomhash":"85c3b55563fe22488649854abdcd8d62",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108701715,
-    "wof:lastmodified":1690930226,
+    "wof:lastmodified":1695886670,
     "wof:name":"San Rafael",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/110/870/171/7/1108701717.geojson
+++ b/data/110/870/171/7/1108701717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004339,
-    "geom:area_square_m":51870968.929531,
+    "geom:area_square_m":51871017.566554,
     "geom:bbox":"-88.259697,14.768306,-88.168915,14.867198",
     "geom:latitude":14.81962,
     "geom:longitude":-88.204501,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"HN.SB.CE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504656,
-    "wof:geomhash":"92377ac94cac1a8f56b43eaf20f81ecc",
+    "wof:geomhash":"1b6739416f16699c662d4f5ca78f0f9c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108701717,
-    "wof:lastmodified":1627522185,
+    "wof:lastmodified":1695886663,
     "wof:name":"Santa Ana o Las Lomas",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/110/870/171/9/1108701719.geojson
+++ b/data/110/870/171/9/1108701719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005767,
-    "geom:area_square_m":69037512.05573,
+    "geom:area_square_m":69037512.055512,
     "geom:bbox":"-89.3566436768,14.4225435257,-89.2148361206,14.5478963852",
     "geom:latitude":14.492266,
     "geom:longitude":-89.28428,
@@ -187,9 +187,10 @@
     "wof:concordances":{
         "hasc:id":"HN.OC.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504667,
-    "wof:geomhash":"fb94bd45a7d21097d49d3e1d9514b025",
+    "wof:geomhash":"26475fa71081222dcf41fd0b2ba6a838",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":1108701719,
-    "wof:lastmodified":1566645574,
+    "wof:lastmodified":1695886366,
     "wof:name":"Santa Fe",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/110/870/172/1/1108701721.geojson
+++ b/data/110/870/172/1/1108701721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005205,
-    "geom:area_square_m":62471058.698633,
+    "geom:area_square_m":62471058.698507,
     "geom:bbox":"-88.4863967896,13.8489999771,-88.3713760376,13.9676446915",
     "geom:latitude":13.905217,
     "geom:longitude":-88.426207,
@@ -124,9 +124,10 @@
     "wof:concordances":{
         "hasc:id":"HN.IN.SL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504672,
-    "wof:geomhash":"7117c0514c4c8c938bf8b08f9d83ace3",
+    "wof:geomhash":"5a1a0a2ee969d3cef7012f48fa084f1d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108701721,
-    "wof:lastmodified":1566645558,
+    "wof:lastmodified":1695886365,
     "wof:name":"Santa Lucia",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/110/870/172/3/1108701723.geojson
+++ b/data/110/870/172/3/1108701723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006883,
-    "geom:area_square_m":82302471.176155,
+    "geom:area_square_m":82302538.403801,
     "geom:bbox":"-88.318535,14.69865,-88.221321,14.815631",
     "geom:latitude":14.754995,
     "geom:longitude":-88.270597,
@@ -168,9 +168,10 @@
     "wof:concordances":{
         "hasc:id":"HN.SB.SR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504677,
-    "wof:geomhash":"3ad452c16e4194c5056ed440493baa39",
+    "wof:geomhash":"b50485e04d29d88f773d200f27d4594d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1108701723,
-    "wof:lastmodified":1636495827,
+    "wof:lastmodified":1695886665,
     "wof:name":"Santa Rita",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/110/870/172/5/1108701725.geojson
+++ b/data/110/870/172/5/1108701725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025713,
-    "geom:area_square_m":307404458.425241,
+    "geom:area_square_m":307404321.17548,
     "geom:bbox":"-88.93911,14.706836,-88.641006,14.910702",
     "geom:latitude":14.796275,
     "geom:longitude":-88.776599,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"HN.CP.SC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504694,
-    "wof:geomhash":"bf0503e187faa2b8fccebe1b3f2537e6",
+    "wof:geomhash":"eeb4a93d6076dca6964b104640cdf370",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108701725,
-    "wof:lastmodified":1627522186,
+    "wof:lastmodified":1695886665,
     "wof:name":"Sta. Rosa de Copan",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/110/870/172/7/1108701727.geojson
+++ b/data/110/870/172/7/1108701727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125822,
-    "geom:area_square_m":1508435373.616253,
+    "geom:area_square_m":1508435373.616165,
     "geom:bbox":"-87.4724655151,13.8951311111,-87.0053939819,14.3719415665",
     "geom:latitude":14.175831,
     "geom:longitude":-87.251074,
@@ -399,9 +399,10 @@
     "wof:concordances":{
         "hasc:id":"HN.FM.DC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504704,
-    "wof:geomhash":"0ca8db5cbffe6a1a9c3e36462c656c52",
+    "wof:geomhash":"c5db11caf2d4899cbe7af312cbd00197",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -411,7 +412,7 @@
         }
     ],
     "wof:id":1108701727,
-    "wof:lastmodified":1566645557,
+    "wof:lastmodified":1695886363,
     "wof:name":"Tegucigalpa",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/110/870/173/1/1108701731.geojson
+++ b/data/110/870/173/1/1108701731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017257,
-    "geom:area_square_m":205957504.475327,
+    "geom:area_square_m":205957897.244179,
     "geom:bbox":"-88.373734,15.062902,-88.161072,15.262318",
     "geom:latitude":15.160498,
     "geom:longitude":-88.260667,
@@ -253,9 +253,10 @@
     "wof:concordances":{
         "hasc:id":"HN.CP.TC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504715,
-    "wof:geomhash":"f4eabe04f92a2d39b294aab86dba7242",
+    "wof:geomhash":"4928af14c5035cb2a1174c2951a5bfb2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -265,7 +266,7 @@
         }
     ],
     "wof:id":1108701731,
-    "wof:lastmodified":1636495826,
+    "wof:lastmodified":1695886664,
     "wof:name":"Trinidad",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/110/870/173/3/1108701733.geojson
+++ b/data/110/870/173/3/1108701733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003102,
-    "geom:area_square_m":37220394.046276,
+    "geom:area_square_m":37220193.467491,
     "geom:bbox":"-88.616791,13.978364,-88.519417,14.037345",
     "geom:latitude":14.008783,
     "geom:longitude":-88.56423,
@@ -561,9 +561,10 @@
     "wof:concordances":{
         "hasc:id":"HN.LE.VI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1474504734,
-    "wof:geomhash":"094fdffef10456b70b1a2d1fbcdc7b85",
+    "wof:geomhash":"5d857146d38abfb1e1d6fef12d649411",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -573,7 +574,7 @@
         }
     ],
     "wof:id":1108701733,
-    "wof:lastmodified":1636495826,
+    "wof:lastmodified":1695886664,
     "wof:name":"Virginia",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/169/617/421169617.geojson
+++ b/data/421/169/617/421169617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01311,
-    "geom:area_square_m":156950550.811577,
+    "geom:area_square_m":156950309.047964,
     "geom:bbox":"-88.856079,14.413155,-88.714531,14.549607",
     "geom:latitude":14.48504,
     "geom:longitude":-88.783104,
@@ -120,12 +120,13 @@
         "qs_pg:id":223168,
         "wd:id":"Q816339"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008817,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6fbaa9df861b1d718c1aa841e7d4e66c",
+    "wof:geomhash":"3496b0ff0d0eb7c679576896ff6d2532",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421169617,
-    "wof:lastmodified":1690930240,
+    "wof:lastmodified":1695886602,
     "wof:name":"Belen Gualcho",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/169/619/421169619.geojson
+++ b/data/421/169/619/421169619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042962,
-    "geom:area_square_m":511392711.74341,
+    "geom:area_square_m":511392903.547403,
     "geom:bbox":"-85.853912,15.567088,-85.626236,15.858206",
     "geom:latitude":15.706898,
     "geom:longitude":-85.737778,
@@ -130,12 +130,13 @@
         "wd:id":"Q22089",
         "wk:page":"Bonito Oriental"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008817,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"274873d90b41c24a13300c9c53a4ffa0",
+    "wof:geomhash":"60959f736c7eebd8e204c39724319413",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421169619,
-    "wof:lastmodified":1690930241,
+    "wof:lastmodified":1695886603,
     "wof:name":"Bonito Oriental",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/169/621/421169621.geojson
+++ b/data/421/169/621/421169621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010534,
-    "geom:area_square_m":126123365.81485,
+    "geom:area_square_m":126123270.448464,
     "geom:bbox":"-89.209091,14.381566,-89.066437,14.529972",
     "geom:latitude":14.461224,
     "geom:longitude":-89.122618,
@@ -114,12 +114,13 @@
         "qs_pg:id":223182,
         "wd:id":"Q2394150"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008817,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cec64778e69af140a80c0070b6f4cf68",
+    "wof:geomhash":"40ce80af1e5a1bee5265f7e91e74a36d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421169621,
-    "wof:lastmodified":1690930240,
+    "wof:lastmodified":1695886604,
     "wof:name":"Sinuapa",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/170/691/421170691.geojson
+++ b/data/421/170/691/421170691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.609355,
-    "geom:area_square_m":7292043164.557492,
+    "geom:area_square_m":7292043164.55864,
     "geom:bbox":"-86.0016784668,14.0456724167,-85.0215454102,15.083024025",
     "geom:latitude":14.581188,
     "geom:longitude":-85.554974,
@@ -130,12 +130,13 @@
         "hasc:id":"HN.OL.CT",
         "qs_pg:id":1195434
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008864,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bb5744c5c60b48d77737106f7c152abf",
+    "wof:geomhash":"73f6e67250140e9bfd3c3a6015a96142",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421170691,
-    "wof:lastmodified":1582319358,
+    "wof:lastmodified":1695886668,
     "wof:name":"Catacamas",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/170/693/421170693.geojson
+++ b/data/421/170/693/421170693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038841,
-    "geom:area_square_m":462439757.406532,
+    "geom:area_square_m":462440197.480086,
     "geom:bbox":"-87.325584,15.427526,-87.127106,15.83218",
     "geom:latitude":15.663049,
     "geom:longitude":-87.235419,
@@ -121,12 +121,13 @@
         "wd:id":"Q949593",
         "wk:page":"Esparta"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008864,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28d32c753dff06aa39c191bfa5899d7a",
+    "wof:geomhash":"e41b8b5be9a5b8fa2e70536498d3c935",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421170693,
-    "wof:lastmodified":1690930307,
+    "wof:lastmodified":1695886664,
     "wof:name":"Esparta",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/170/695/421170695.geojson
+++ b/data/421/170/695/421170695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023395,
-    "geom:area_square_m":278532125.543158,
+    "geom:area_square_m":278532229.660993,
     "geom:bbox":"-87.020592,15.546366,-86.846603,15.770892",
     "geom:latitude":15.667571,
     "geom:longitude":-86.925238,
@@ -161,12 +161,13 @@
         "hasc:id":"HN.AT.EP",
         "qs_pg:id":1195464
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008864,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa8f2dea7be2bafa2220bbdb06e3f0eb",
+    "wof:geomhash":"bea36e1062bcd53d6f652ee7c64b797e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":421170695,
-    "wof:lastmodified":1636495867,
+    "wof:lastmodified":1695886694,
     "wof:name":"El Porvenir",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/170/697/421170697.geojson
+++ b/data/421/170/697/421170697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.325111,
-    "geom:area_square_m":3872587462.164439,
+    "geom:area_square_m":3872586915.70912,
     "geom:bbox":"-85.672813,15.071033,-84.999565,15.987597",
     "geom:latitude":15.566352,
     "geom:longitude":-85.230759,
@@ -121,12 +121,13 @@
         "wd:id":"Q2036829",
         "wk:page":"Iriona"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008864,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e99468bf14f438c664ded13b2facc171",
+    "wof:geomhash":"4585d86310b7b4c4a2cfbe219bd0f8a9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421170697,
-    "wof:lastmodified":1690930310,
+    "wof:lastmodified":1695886667,
     "wof:name":"Iriona",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/170/699/421170699.geojson
+++ b/data/421/170/699/421170699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044547,
-    "geom:area_square_m":533449744.306117,
+    "geom:area_square_m":533449744.306848,
     "geom:bbox":"-88.2539215088,14.2500495911,-88.0044021606,14.658577919",
     "geom:latitude":14.433512,
     "geom:longitude":-88.153976,
@@ -137,12 +137,13 @@
         "hasc:id":"HN.IN.IN",
         "qs_pg:id":1195467
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008864,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"419f6042e5f110410533bb6f64c98b80",
+    "wof:geomhash":"c97ec67c872b5cfbb54b548503007b0e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421170699,
-    "wof:lastmodified":1582319356,
+    "wof:lastmodified":1695886666,
     "wof:name":"Intibuca",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/170/703/421170703.geojson
+++ b/data/421/170/703/421170703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005653,
-    "geom:area_square_m":67063453.610746,
+    "geom:area_square_m":67063371.217272,
     "geom:bbox":"-86.519806,15.945,-86.122475,16.447418",
     "geom:latitude":16.390108,
     "geom:longitude":-86.329821,
@@ -41,7 +41,7 @@
         "Jos\u00e9 Santos Guardiola"
     ],
     "name:eng_x_preferred":[
-        "Jos\u00e9 Santos Guardiola"
+        "Jose Santos Guardiola"
     ],
     "name:eng_x_variant":[
         "Jose Santos Guardiola"
@@ -124,7 +124,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a05c5d26ce8cd279d3f8f47a3a71f1cf",
+    "wof:geomhash":"e48f2a328083bdcb8210507fd80825df",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":421170703,
-    "wof:lastmodified":1690930309,
+    "wof:lastmodified":1694492674,
     "wof:name":"Jose Santos Guardiola",
     "wof:parent_id":85671869,
     "wof:placetype":"county",

--- a/data/421/170/703/421170703.geojson
+++ b/data/421/170/703/421170703.geojson
@@ -119,6 +119,7 @@
         "qs_pg:id":1195483,
         "wd:id":"Q2564825"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008865,
     "wof:geom_alt":[
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421170703,
-    "wof:lastmodified":1694492674,
+    "wof:lastmodified":1695886648,
     "wof:name":"Jose Santos Guardiola",
     "wof:parent_id":85671869,
     "wof:placetype":"county",

--- a/data/421/170/707/421170707.geojson
+++ b/data/421/170/707/421170707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047443,
-    "geom:area_square_m":569095132.908862,
+    "geom:area_square_m":569093994.660823,
     "geom:bbox":"-87.617439,13.919703,-87.353592,14.211001",
     "geom:latitude":14.048234,
     "geom:longitude":-87.495496,
@@ -121,12 +121,13 @@
         "wd:id":"Q2316676",
         "wk:page":"Lepaterique"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008865,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0002cc3bcec180e3286006123ae760d",
+    "wof:geomhash":"2bfc48a1422ce50d6a0f11e80db1b5b9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421170707,
-    "wof:lastmodified":1690930307,
+    "wof:lastmodified":1695886664,
     "wof:name":"Lepaterique",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/170/709/421170709.geojson
+++ b/data/421/170/709/421170709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072157,
-    "geom:area_square_m":859716480.445117,
+    "geom:area_square_m":859716480.443124,
     "geom:bbox":"-88.4109420776,15.3729991913,-87.849395752,15.6294260025",
     "geom:latitude":15.515071,
     "geom:longitude":-88.114588,
@@ -223,12 +223,13 @@
         "hasc:id":"HN.CR.SP",
         "qs_pg:id":1195554
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008865,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9920099a2ad5fd6c56693da20ce67408",
+    "wof:geomhash":"953b9971972099dc79b833e982628619",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -238,7 +239,7 @@
         }
     ],
     "wof:id":421170709,
-    "wof:lastmodified":1582319351,
+    "wof:lastmodified":1695886663,
     "wof:name":"San Pedro Sula",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/170/711/421170711.geojson
+++ b/data/421/170/711/421170711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064695,
-    "geom:area_square_m":772684257.279676,
+    "geom:area_square_m":772685105.066066,
     "geom:bbox":"-88.061417,14.799693,-87.73156,15.193937",
     "geom:latitude":15.006772,
     "geom:longitude":-87.876734,
@@ -91,12 +91,13 @@
         "qs_pg:id":1195577,
         "wd:id":"Q2180652"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008865,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"be48fb0c581ba699288fd033824b9c2b",
+    "wof:geomhash":"3eb39ee0889210d45de60a604e1d8fbd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421170711,
-    "wof:lastmodified":1627522186,
+    "wof:lastmodified":1695886664,
     "wof:name":"Santa Cruz de Yojoa",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/170/947/421170947.geojson
+++ b/data/421/170/947/421170947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004847,
-    "geom:area_square_m":58124829.289907,
+    "geom:area_square_m":58124749.759632,
     "geom:bbox":"-87.135292,14.081243,-87.05468,14.179078",
     "geom:latitude":14.12775,
     "geom:longitude":-87.095387,
@@ -121,12 +121,13 @@
         "wd:id":"Q1645159",
         "wk:page":"Santa Luc\u00eda, Francisco Moraz\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008875,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"799a526257d4c3e7f4d6d03e66b158ca",
+    "wof:geomhash":"7631e60370d74ff5367ab8db8f477480",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421170947,
-    "wof:lastmodified":1690930308,
+    "wof:lastmodified":1695886666,
     "wof:name":"Santa Lucia",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/170/949/421170949.geojson
+++ b/data/421/170/949/421170949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025295,
-    "geom:area_square_m":302226600.606886,
+    "geom:area_square_m":302226287.293326,
     "geom:bbox":"-88.320419,14.814534,-88.050163,15.000619",
     "geom:latitude":14.922356,
     "geom:longitude":-88.18187,
@@ -231,12 +231,13 @@
         "qs_pg:id":1197984,
         "wd:id":"Q2283714"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008875,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d68401dff1eed94d5c76bef0786d2d08",
+    "wof:geomhash":"bb6b8f7b2164d61f7cda2aac21a2a030",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -246,7 +247,7 @@
         }
     ],
     "wof:id":421170949,
-    "wof:lastmodified":1690930308,
+    "wof:lastmodified":1695886695,
     "wof:name":"Santa Barbara",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/172/427/421172427.geojson
+++ b/data/421/172/427/421172427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055206,
-    "geom:area_square_m":657234447.034706,
+    "geom:area_square_m":657234447.03413,
     "geom:bbox":"-86.8843154907,15.5432367325,-86.5980300903,15.7995119095",
     "geom:latitude":15.678204,
     "geom:longitude":-86.742786,
@@ -181,12 +181,13 @@
         "hasc:id":"HN.AT.LC",
         "qs_pg:id":1310467
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008940,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"915e1080cbb57c667a7c6c79650ea67f",
+    "wof:geomhash":"63d003b8b716799e6a60144596d53689",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -196,7 +197,7 @@
         }
     ],
     "wof:id":421172427,
-    "wof:lastmodified":1582319308,
+    "wof:lastmodified":1695886636,
     "wof:name":"La Ceiba",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/172/429/421172429.geojson
+++ b/data/421/172/429/421172429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033199,
-    "geom:area_square_m":395259882.269606,
+    "geom:area_square_m":395260099.470742,
     "geom:bbox":"-88.472916,15.513882,-87.955826,15.803856",
     "geom:latitude":15.666537,
     "geom:longitude":-88.185153,
@@ -141,12 +141,13 @@
         "qs_pg:id":1310476,
         "wd:id":"Q520386"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008940,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e74af29920ba3941bf681f07d31db71e",
+    "wof:geomhash":"2125796d1732b2e367581bea34b07e7e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":421172429,
-    "wof:lastmodified":1690930273,
+    "wof:lastmodified":1695886637,
     "wof:name":"Omoa",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/172/431/421172431.geojson
+++ b/data/421/172/431/421172431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005416,
-    "geom:area_square_m":64268078.378998,
+    "geom:area_square_m":64268160.610167,
     "geom:bbox":"-86.60318,16.267015,-86.433578,16.383762",
     "geom:latitude":16.333778,
     "geom:longitude":-86.520127,
@@ -176,12 +176,13 @@
         "qs_pg:id":1310477,
         "wd:id":"Q1419813"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008941,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2b129e987eb293f0f5c846312553b8dd",
+    "wof:geomhash":"994eb92f3ca2cf026d28ca5c0de5fec2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":421172431,
-    "wof:lastmodified":1690930272,
+    "wof:lastmodified":1695886635,
     "wof:name":"Roatan",
     "wof:parent_id":85671869,
     "wof:placetype":"county",

--- a/data/421/172/435/421172435.geojson
+++ b/data/421/172/435/421172435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097566,
-    "geom:area_square_m":1161389774.523783,
+    "geom:area_square_m":1161389774.523688,
     "geom:bbox":"-87.8020401001,15.5058069229,-87.3668899536,15.9284915924",
     "geom:latitude":15.70484,
     "geom:longitude":-87.582812,
@@ -127,12 +127,13 @@
         "hasc:id":"HN.AT.TE",
         "qs_pg:id":1310480
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008942,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0d85e5e3e95ce60b41b0dc84153c7d77",
+    "wof:geomhash":"2c087a011437263b6e6b8932b4a476fe",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421172435,
-    "wof:lastmodified":1582319309,
+    "wof:lastmodified":1695886637,
     "wof:name":"Tela",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/172/467/421172467.geojson
+++ b/data/421/172/467/421172467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03602,
-    "geom:area_square_m":431380434.595668,
+    "geom:area_square_m":431380577.600605,
     "geom:bbox":"-87.237663,14.296724,-86.87925,14.482334",
     "geom:latitude":14.409443,
     "geom:longitude":-87.067835,
@@ -204,12 +204,13 @@
         "wd:id":"Q2603720",
         "wk:page":"Talanga"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459008943,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d60d97428fba89602bf46a82244836bc",
+    "wof:geomhash":"605dc6321e997837144f312d5862d0f8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -219,7 +220,7 @@
         }
     ],
     "wof:id":421172467,
-    "wof:lastmodified":1690930273,
+    "wof:lastmodified":1695886640,
     "wof:name":"Talanga",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/175/543/421175543.geojson
+++ b/data/421/175/543/421175543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019269,
-    "geom:area_square_m":230835595.673437,
+    "geom:area_square_m":230835479.405687,
     "geom:bbox":"-88.826172,14.263861,-88.64138,14.442939",
     "geom:latitude":14.34459,
     "geom:longitude":-88.734362,
@@ -91,12 +91,13 @@
         "hasc:id":"HN.LE.SS",
         "qs_pg:id":981490
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009071,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"328c726a12d7e7b296d6c125096b9468",
+    "wof:geomhash":"dcd936510b3a5f097830f51d0fb45e3f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421175543,
-    "wof:lastmodified":1627522185,
+    "wof:lastmodified":1695886662,
     "wof:name":"San Sebastian",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/177/087/421177087.geojson
+++ b/data/421/177/087/421177087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.329096,
-    "geom:area_square_m":3926746566.412498,
+    "geom:area_square_m":3926747137.541359,
     "geom:bbox":"-84.999977,14.724362,-84.508354,15.706491",
     "geom:latitude":15.210725,
     "geom:longitude":-84.783092,
@@ -124,12 +124,13 @@
         "wd:id":"Q2604385",
         "wk:page":"Wampusirpi"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009132,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"70829a810158e6df2531a2f889ea1b74",
+    "wof:geomhash":"763bbb0fdb2098aa3ab33aa84e3b1456",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421177087,
-    "wof:lastmodified":1690930312,
+    "wof:lastmodified":1695886671,
     "wof:name":"Wampusirpi",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/421/177/939/421177939.geojson
+++ b/data/421/177/939/421177939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006562,
-    "geom:area_square_m":78455161.914201,
+    "geom:area_square_m":78455011.932487,
     "geom:bbox":"-88.38961,14.719244,-88.272438,14.823744",
     "geom:latitude":14.772382,
     "geom:longitude":-88.336231,
@@ -118,12 +118,13 @@
         "wd:id":"Q1823994",
         "wk:page":"El Nispero"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009165,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"283e5160dbd54058be9563b445b82b50",
+    "wof:geomhash":"73fd5e79bc6052f4ad90121dd732ab7a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421177939,
-    "wof:lastmodified":1690930311,
+    "wof:lastmodified":1695886671,
     "wof:name":"El Nispero",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/177/943/421177943.geojson
+++ b/data/421/177/943/421177943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048284,
-    "geom:area_square_m":580777245.927139,
+    "geom:area_square_m":580777245.926632,
     "geom:bbox":"-86.9643783569,13.2673950195,-86.70362854,13.564953804",
     "geom:latitude":13.405705,
     "geom:longitude":-86.822361,
@@ -115,12 +115,13 @@
         "qs_pg:id":14457,
         "wd:id":"Q2552667"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009165,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3d41e57fbf2b6420b036c8fd052e78f7",
+    "wof:geomhash":"8398a44c299eec269972139f6e37ffe6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421177943,
-    "wof:lastmodified":1582319361,
+    "wof:lastmodified":1695886672,
     "wof:name":"San Marcos de Colon",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/179/727/421179727.geojson
+++ b/data/421/179/727/421179727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013581,
-    "geom:area_square_m":162682758.47883,
+    "geom:area_square_m":162682625.059782,
     "geom:bbox":"-88.422752,14.280832,-88.258743,14.466297",
     "geom:latitude":14.360026,
     "geom:longitude":-88.343841,
@@ -34,6 +34,9 @@
     "mz:is_current":1,
     "mz:min_zoom":6.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "San Miguel Guancapia"
+    ],
     "name:eng_x_variant":[
         "San Miguelito"
     ],
@@ -79,7 +82,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"08a3021936ec472c3e3a36b1990bd7dc",
+    "wof:geomhash":"55f9b47373d1496d5eb92eff788570d8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":421179727,
-    "wof:lastmodified":1628266712,
+    "wof:lastmodified":1694492881,
     "wof:name":"San Miguel Guancapia",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/179/727/421179727.geojson
+++ b/data/421/179/727/421179727.geojson
@@ -77,6 +77,7 @@
         "hasc:id":"HN.FM.SM",
         "qs_pg:id":237256
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009231,
     "wof:geom_alt":[
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":421179727,
-    "wof:lastmodified":1694492881,
+    "wof:lastmodified":1695886394,
     "wof:name":"San Miguel Guancapia",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/179/809/421179809.geojson
+++ b/data/421/179/809/421179809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019364,
-    "geom:area_square_m":231561069.897643,
+    "geom:area_square_m":231561201.585536,
     "geom:bbox":"-88.031502,14.650738,-87.880623,14.881539",
     "geom:latitude":14.741064,
     "geom:longitude":-87.95481,
@@ -121,12 +121,13 @@
         "wd:id":"Q1643763",
         "wk:page":"Taulab\u00e9"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009233,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"179738e6139e83a51e9e7658d8cc2851",
+    "wof:geomhash":"d8b17caf4cda401957d01e8e6f0fa517",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421179809,
-    "wof:lastmodified":1690930324,
+    "wof:lastmodified":1695886677,
     "wof:name":"Taulabe",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/181/669/421181669.geojson
+++ b/data/421/181/669/421181669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024979,
-    "geom:area_square_m":299347460.491138,
+    "geom:area_square_m":299347236.976001,
     "geom:bbox":"-88.334023,14.169457,-88.15406,14.391555",
     "geom:latitude":14.263776,
     "geom:longitude":-88.248938,
@@ -117,12 +117,13 @@
         "qs_pg:id":499946,
         "wd:id":"Q2394043"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009303,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c500ef8f57cbe5da62b48a431ee1d6b5",
+    "wof:geomhash":"d3da8eab59d6b5e8d67c6d7abf23ac9c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421181669,
-    "wof:lastmodified":1690930276,
+    "wof:lastmodified":1695886641,
     "wof:name":"Yamaranguila",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/181/805/421181805.geojson
+++ b/data/421/181/805/421181805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034423,
-    "geom:area_square_m":411452088.379249,
+    "geom:area_square_m":411452200.57694,
     "geom:bbox":"-87.901863,14.705712,-87.682419,14.981928",
     "geom:latitude":14.839673,
     "geom:longitude":-87.780173,
@@ -120,12 +120,13 @@
         "qs_pg:id":504924,
         "wd:id":"Q2098619"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009307,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"509d725822e9a92f18295f1af9c8a89b",
+    "wof:geomhash":"b291bb66321bb299bf71b8430415fc72",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421181805,
-    "wof:lastmodified":1690930276,
+    "wof:lastmodified":1695886641,
     "wof:name":"Meambar",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/181/807/421181807.geojson
+++ b/data/421/181/807/421181807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056406,
-    "geom:area_square_m":678212503.396755,
+    "geom:area_square_m":678212443.587898,
     "geom:bbox":"-87.722664,13.248306,-87.366638,13.669672",
     "geom:latitude":13.493443,
     "geom:longitude":-87.538179,
@@ -194,12 +194,13 @@
         "qs_pg:id":504933,
         "wd:id":"Q633929"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009307,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"76ac2e605d6b747a367a7c68d9f54426",
+    "wof:geomhash":"1e3c53aee36817e249bd761f51b3ebbc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":421181807,
-    "wof:lastmodified":1690930277,
+    "wof:lastmodified":1695886679,
     "wof:name":"Nacaome",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/181/809/421181809.geojson
+++ b/data/421/181/809/421181809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.557243,
-    "geom:area_square_m":6655141908.681601,
+    "geom:area_square_m":6655141562.710467,
     "geom:bbox":"-84.793961,14.615577,-83.385826,15.662786",
     "geom:latitude":15.01438,
     "geom:longitude":-84.078578,
@@ -151,12 +151,13 @@
         "hasc:id":"HN.GD.PL",
         "qs_pg:id":504946
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009307,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7698dd95da1396aba332f43c39b94ed1",
+    "wof:geomhash":"389a44293ad441676be737f5b8f89554",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":421181809,
-    "wof:lastmodified":1636495858,
+    "wof:lastmodified":1695886683,
     "wof:name":"Puerto Lempira",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/421/181/917/421181917.geojson
+++ b/data/421/181/917/421181917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006954,
-    "geom:area_square_m":83173056.010704,
+    "geom:area_square_m":83173061.809333,
     "geom:bbox":"-88.796288,14.642513,-88.656967,14.722956",
     "geom:latitude":14.684342,
     "geom:longitude":-88.73384,
@@ -111,12 +111,13 @@
         "qs_pg:id":511801,
         "wd:id":"Q1645820"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009312,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"66136a156ce1f264b8e843cf17356e2a",
+    "wof:geomhash":"9e7f07f9299f4ec10a3d86ca63fd5f6e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421181917,
-    "wof:lastmodified":1690930279,
+    "wof:lastmodified":1695886643,
     "wof:name":"Talgua",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/181/921/421181921.geojson
+++ b/data/421/181/921/421181921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015063,
-    "geom:area_square_m":179604137.322478,
+    "geom:area_square_m":179604137.322326,
     "geom:bbox":"-86.9487609863,15.278842926,-86.6951446533,15.4251937866",
     "geom:latitude":15.35646,
     "geom:longitude":-86.821847,
@@ -134,12 +134,13 @@
         "hasc:id":"HN.YO.AR",
         "qs_pg:id":511772
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009312,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3527d2a482d671d719aafaa09e7bbc2d",
+    "wof:geomhash":"a59a3d08220b5c6486ab0f0bbc2a5064",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421181921,
-    "wof:lastmodified":1582319323,
+    "wof:lastmodified":1695886642,
     "wof:name":"Arenal",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/181/923/421181923.geojson
+++ b/data/421/181/923/421181923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023025,
-    "geom:area_square_m":276762758.336892,
+    "geom:area_square_m":276763015.424274,
     "geom:bbox":"-87.021393,13.468699,-86.784912,13.661278",
     "geom:latitude":13.563689,
     "geom:longitude":-86.901728,
@@ -120,12 +120,13 @@
         "qs_pg:id":511784,
         "wd:id":"Q2358973"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009312,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7877a322ff0126c68ede27b837c9089a",
+    "wof:geomhash":"44c6c7e63545a293e27f3624032111fc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421181923,
-    "wof:lastmodified":1690930276,
+    "wof:lastmodified":1695886642,
     "wof:name":"Morolica",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/181/925/421181925.geojson
+++ b/data/421/181/925/421181925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015222,
-    "geom:area_square_m":182829361.94748,
+    "geom:area_square_m":182829404.84624,
     "geom:bbox":"-87.244461,13.653211,-87.100189,13.84844",
     "geom:latitude":13.751473,
     "geom:longitude":-87.161367,
@@ -118,12 +118,13 @@
         "wd:id":"Q2392491",
         "wk:page":"Nueva Armenia"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009312,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"735dbf4a974c115f89f2ea88ce18ea21",
+    "wof:geomhash":"89fe4c6e579ad90ce9e8a60fa2e43845",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421181925,
-    "wof:lastmodified":1690930277,
+    "wof:lastmodified":1695886642,
     "wof:name":"Nueva Armenia",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/182/069/421182069.geojson
+++ b/data/421/182/069/421182069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010605,
-    "geom:area_square_m":127380637.880857,
+    "geom:area_square_m":127380696.913553,
     "geom:bbox":"-87.031166,13.691128,-86.849724,13.798674",
     "geom:latitude":13.747848,
     "geom:longitude":-86.948601,
@@ -118,12 +118,13 @@
         "wd:id":"Q2392435",
         "wk:page":"San Lucas, El Para\u00edso"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009317,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0fa5970ecf2f8f836db3fcb201eb52c6",
+    "wof:geomhash":"d4340c5726f0d4cee2d6384c35b7140f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421182069,
-    "wof:lastmodified":1690930340,
+    "wof:lastmodified":1695886691,
     "wof:name":"San Lucas",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/173/421182173.geojson
+++ b/data/421/182/173/421182173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160105,
-    "geom:area_square_m":1909414978.897625,
+    "geom:area_square_m":1909415812.819281,
     "geom:bbox":"-85.947891,15.032131,-85.458389,15.59628",
     "geom:latitude":15.316163,
     "geom:longitude":-85.719685,
@@ -118,12 +118,13 @@
         "wd:id":"Q2394385",
         "wk:page":"San Esteban, Olancho"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009321,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fc43979f7eff7097d8cdb9d808fd04e4",
+    "wof:geomhash":"6ea78b8a4466cabaa764639ae90fff41",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421182173,
-    "wof:lastmodified":1690930331,
+    "wof:lastmodified":1695886681,
     "wof:name":"San Esteban",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/182/565/421182565.geojson
+++ b/data/421/182/565/421182565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008648,
-    "geom:area_square_m":103358755.3399,
+    "geom:area_square_m":103358755.339853,
     "geom:bbox":"-88.3984451294,14.7913284302,-88.2526779175,14.9108772278",
     "geom:latitude":14.851814,
     "geom:longitude":-88.337316,
@@ -113,12 +113,13 @@
         "hasc:id":"HN.SB.AR",
         "qs_pg:id":919266
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009334,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"db84abc594a033cf356991f2f3782f7a",
+    "wof:geomhash":"c10f50bf536a2a9041c506aec3abcc8f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421182565,
-    "wof:lastmodified":1582319386,
+    "wof:lastmodified":1695886689,
     "wof:name":"Arada",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/182/569/421182569.geojson
+++ b/data/421/182/569/421182569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008399,
-    "geom:area_square_m":100891684.018831,
+    "geom:area_square_m":100891730.547486,
     "geom:bbox":"-87.748367,13.672516,-87.642227,13.795939",
     "geom:latitude":13.732982,
     "geom:longitude":-87.690376,
@@ -123,12 +123,13 @@
         "qs_pg:id":919267,
         "wd:id":"Q2001506"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009334,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a0c875abd1a7d190d94d7822e5960474",
+    "wof:geomhash":"43ecd1b3adcdc68c7af06533dca14130",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421182569,
-    "wof:lastmodified":1690930326,
+    "wof:lastmodified":1695886677,
     "wof:name":"Aramecina",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/182/573/421182573.geojson
+++ b/data/421/182/573/421182573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015344,
-    "geom:area_square_m":184110622.013549,
+    "geom:area_square_m":184110552.983488,
     "geom:bbox":"-88.357811,13.889531,-88.204643,14.087741",
     "geom:latitude":13.980283,
     "geom:longitude":-88.279613,
@@ -114,12 +114,13 @@
         "qs_pg:id":919269,
         "wd:id":"Q2393388"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009334,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0495a4f6bf46b2e1349cfabebc8769bb",
+    "wof:geomhash":"c3a793052f718887a78a28482866119e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421182573,
-    "wof:lastmodified":1690930336,
+    "wof:lastmodified":1695886686,
     "wof:name":"Colomoncagua",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/182/575/421182575.geojson
+++ b/data/421/182/575/421182575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021591,
-    "geom:area_square_m":257815484.974453,
+    "geom:area_square_m":257815484.974531,
     "geom:bbox":"-89.0852661133,14.9547634125,-88.9133605957,15.1626176834",
     "geom:latitude":15.054445,
     "geom:longitude":-88.987051,
@@ -111,12 +111,13 @@
         "hasc:id":"HN.CP.EP",
         "qs_pg:id":919273
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009334,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d9407930bddb3f86a754a5d8b8a186db",
+    "wof:geomhash":"58dcf3866499c502e5dd4ec43a0b3943",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421182575,
-    "wof:lastmodified":1582319377,
+    "wof:lastmodified":1695886683,
     "wof:name":"El Paraiso",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/182/579/421182579.geojson
+++ b/data/421/182/579/421182579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007445,
-    "geom:area_square_m":89298936.973033,
+    "geom:area_square_m":89298860.255983,
     "geom:bbox":"-88.739098,14.009441,-88.635864,14.140099",
     "geom:latitude":14.071347,
     "geom:longitude":-88.686333,
@@ -121,12 +121,13 @@
         "wd:id":"Q2394130",
         "wk:page":"La Virtud"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009334,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f328e09617880b389c84672efc1e7094",
+    "wof:geomhash":"20459fa05f4a395165b320afeb876dd3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421182579,
-    "wof:lastmodified":1690930343,
+    "wof:lastmodified":1695886693,
     "wof:name":"La Virtud",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/581/421182581.geojson
+++ b/data/421/182/581/421182581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025728,
-    "geom:area_square_m":308462205.364393,
+    "geom:area_square_m":308462472.401463,
     "geom:bbox":"-87.785797,14.047388,-87.477798,14.24691",
     "geom:latitude":14.159242,
     "geom:longitude":-87.63319,
@@ -120,12 +120,13 @@
         "qs_pg:id":919276,
         "wd:id":"Q1643754"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009335,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3c7cc364b4da92cef9625a73c9b28828",
+    "wof:geomhash":"e7b6b89dd69f473e75839b2b71fe3e2f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421182581,
-    "wof:lastmodified":1690930333,
+    "wof:lastmodified":1695886684,
     "wof:name":"Lamani",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/182/583/421182583.geojson
+++ b/data/421/182/583/421182583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011378,
-    "geom:area_square_m":136710028.532109,
+    "geom:area_square_m":136710036.321074,
     "geom:bbox":"-87.693848,13.582998,-87.56739,13.743505",
     "geom:latitude":13.657125,
     "geom:longitude":-87.629099,
@@ -126,12 +126,13 @@
         "qs_pg:id":919277,
         "wd:id":"Q2395542"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009335,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"64914f88e95bfea0cf37d3ab4fb21032",
+    "wof:geomhash":"9205e5cf3ce3dc8591e4b1713d4ee3b3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421182583,
-    "wof:lastmodified":1690930344,
+    "wof:lastmodified":1695886693,
     "wof:name":"Langue",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/182/587/421182587.geojson
+++ b/data/421/182/587/421182587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006782,
-    "geom:area_square_m":81124577.813091,
+    "geom:area_square_m":81124628.934456,
     "geom:bbox":"-88.753479,14.611496,-88.564728,14.7377",
     "geom:latitude":14.68079,
     "geom:longitude":-88.658755,
@@ -121,12 +121,13 @@
         "wd:id":"Q2293008",
         "wk:page":"Las Flores, Lempira"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009335,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"faf2d3e53bf6e8d74396d840571c899b",
+    "wof:geomhash":"1e7d9e28e65eaf7e17af939f44d0d027",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421182587,
-    "wof:lastmodified":1690930336,
+    "wof:lastmodified":1695886685,
     "wof:name":"Las Flores",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/589/421182589.geojson
+++ b/data/421/182/589/421182589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004443,
-    "geom:area_square_m":53140210.154294,
+    "geom:area_square_m":53140385.71188,
     "geom:bbox":"-89.148705,14.656267,-89.030624,14.726662",
     "geom:latitude":14.69108,
     "geom:longitude":-89.098786,
@@ -160,12 +160,13 @@
         "wd:id":"Q281256",
         "wk:page":"San Fernando, Ocotepeque"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009335,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6cf0360e93d679ac5098c6815261b4a5",
+    "wof:geomhash":"6bb51f964350fa0e98edd3beb812b722",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":421182589,
-    "wof:lastmodified":1690930335,
+    "wof:lastmodified":1695886699,
     "wof:name":"San Fernando",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/182/591/421182591.geojson
+++ b/data/421/182/591/421182591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00745,
-    "geom:area_square_m":89507950.137079,
+    "geom:area_square_m":89507912.319984,
     "geom:bbox":"-87.598015,13.61873,-87.459496,13.719526",
     "geom:latitude":13.669635,
     "geom:longitude":-87.545741,
@@ -94,12 +94,13 @@
         "qs_pg:id":919281,
         "wd:id":"Q1019299"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009335,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"537562860ab60fc83e7e85da88bae60d",
+    "wof:geomhash":"4927e83130449a1d803d688b0ac590ae",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421182591,
-    "wof:lastmodified":1690930340,
+    "wof:lastmodified":1695886658,
     "wof:name":"San Francisco de Coray",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/182/887/421182887.geojson
+++ b/data/421/182/887/421182887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015878,
-    "geom:area_square_m":190518013.239825,
+    "geom:area_square_m":190518186.758255,
     "geom:bbox":"-87.699791,13.876487,-87.591293,14.088005",
     "geom:latitude":13.983372,
     "geom:longitude":-87.643033,
@@ -129,12 +129,13 @@
         "qs_pg:id":956663,
         "wd:id":"Q2394072"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"54fc52ca92932a48322507551b44a4f5",
+    "wof:geomhash":"bb7e329a77bd6b83b6316170c36a6e59",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421182887,
-    "wof:lastmodified":1690930329,
+    "wof:lastmodified":1695886679,
     "wof:name":"Aguanqueterique",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/182/889/421182889.geojson
+++ b/data/421/182/889/421182889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.180533,
-    "geom:area_square_m":2149323761.853328,
+    "geom:area_square_m":2149324405.568086,
     "geom:bbox":"-85.000069,15.409341,-84.282249,15.886182",
     "geom:latitude":15.672377,
     "geom:longitude":-84.649989,
@@ -173,12 +173,13 @@
         "qs_pg:id":956664,
         "wd:id":"Q2102693"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b35ee6a4dd61c3b24bbc46685f8ba244",
+    "wof:geomhash":"e9127405db7c272c2fcd59edfffafe01",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":421182889,
-    "wof:lastmodified":1690930328,
+    "wof:lastmodified":1695886696,
     "wof:name":"Brus Laguna",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/421/182/893/421182893.geojson
+++ b/data/421/182/893/421182893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004452,
-    "geom:area_square_m":53404733.474993,
+    "geom:area_square_m":53405034.314091,
     "geom:bbox":"-88.603081,14.012867,-88.517685,14.097224",
     "geom:latitude":14.056773,
     "geom:longitude":-88.557725,
@@ -118,12 +118,13 @@
         "wd:id":"Q2261478",
         "wk:page":"Candelaria, Lempira"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fcb316b9c8536fc4e771b0f9209bb3fa",
+    "wof:geomhash":"3f4425ec7564b244b77e5297688a708d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421182893,
-    "wof:lastmodified":1690930330,
+    "wof:lastmodified":1695886680,
     "wof:name":"Candelaria",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/895/421182895.geojson
+++ b/data/421/182/895/421182895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011421,
-    "geom:area_square_m":136608361.891023,
+    "geom:area_square_m":136608548.13315,
     "geom:bbox":"-88.915024,14.630263,-88.770927,14.757813",
     "geom:latitude":14.689991,
     "geom:longitude":-88.843571,
@@ -117,12 +117,13 @@
         "qs_pg:id":956666,
         "wd:id":"Q593881"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a2dcec01cd6b70bb1ca068360bd37b10",
+    "wof:geomhash":"79f06234d7fe6392a468ef794c14d6dc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421182895,
-    "wof:lastmodified":1690930330,
+    "wof:lastmodified":1695886680,
     "wof:name":"Cacuyagua",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/182/897/421182897.geojson
+++ b/data/421/182/897/421182897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003452,
-    "geom:area_square_m":41316735.361955,
+    "geom:area_square_m":41316660.201106,
     "geom:bbox":"-89.168732,14.518489,-89.101616,14.612859",
     "geom:latitude":14.557312,
     "geom:longitude":-89.133011,
@@ -117,12 +117,13 @@
         "qs_pg:id":956667,
         "wd:id":"Q2138937"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5186c2d91ed8952634169da9065f263e",
+    "wof:geomhash":"1347d4af214b9e1fadb79aa9679e0b2c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421182897,
-    "wof:lastmodified":1690930341,
+    "wof:lastmodified":1695886691,
     "wof:name":"Dolores Merendon",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/182/901/421182901.geojson
+++ b/data/421/182/901/421182901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003999,
-    "geom:area_square_m":47780287.866942,
+    "geom:area_square_m":47780279.334958,
     "geom:bbox":"-88.898033,14.850087,-88.798126,14.956028",
     "geom:latitude":14.907819,
     "geom:longitude":-88.845218,
@@ -155,12 +155,13 @@
         "hasc:id":"HN.CP.DO",
         "qs_pg:id":956669
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"19b61e8f5fb0013cf391ff8132ccaa10",
+    "wof:geomhash":"da89492d2683f43bedd3d67aca213be0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421182901,
-    "wof:lastmodified":1636495871,
+    "wof:lastmodified":1695886698,
     "wof:name":"Dolores",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/182/903/421182903.geojson
+++ b/data/421/182/903/421182903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008709,
-    "geom:area_square_m":104650457.674423,
+    "geom:area_square_m":104650459.339441,
     "geom:bbox":"-86.888054,13.561423,-86.749092,13.702801",
     "geom:latitude":13.635146,
     "geom:longitude":-86.807255,
@@ -120,12 +120,13 @@
         "qs_pg:id":956670,
         "wd:id":"Q2090091"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b6e39ca147e94444325eb84a1748464f",
+    "wof:geomhash":"976c5c43bc491bb33b19f0c297955828",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421182903,
-    "wof:lastmodified":1690930338,
+    "wof:lastmodified":1695886689,
     "wof:name":"Duyure",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/182/905/421182905.geojson
+++ b/data/421/182/905/421182905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024975,
-    "geom:area_square_m":298843959.681122,
+    "geom:area_square_m":298844258.527868,
     "geom:bbox":"-87.89743,14.492513,-87.620918,14.710433",
     "geom:latitude":14.607286,
     "geom:longitude":-87.742292,
@@ -118,12 +118,13 @@
         "wd:id":"Q1643527",
         "wk:page":"El Rosario, Comayagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c6044bc69f0a2227e4ceedc1c901480c",
+    "wof:geomhash":"58215342041e678881deb9802fe2331a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421182905,
-    "wof:lastmodified":1690930340,
+    "wof:lastmodified":1695886690,
     "wof:name":"El Rosario",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/182/907/421182907.geojson
+++ b/data/421/182/907/421182907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025599,
-    "geom:area_square_m":308320194.374749,
+    "geom:area_square_m":308319923.220113,
     "geom:bbox":"-87.128899,12.983047,-86.915489,13.193145",
     "geom:latitude":13.083814,
     "geom:longitude":-87.025836,
@@ -118,12 +118,13 @@
         "wd:id":"Q1747638",
         "wk:page":"El Triunfo, Choluteca"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"875ebfc684560d885b385c3c2a401a86",
+    "wof:geomhash":"5b03b74dbe59988809301a33eae39d1e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421182907,
-    "wof:lastmodified":1690930327,
+    "wof:lastmodified":1695886677,
     "wof:name":"El Triunfo",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/182/911/421182911.geojson
+++ b/data/421/182/911/421182911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024849,
-    "geom:area_square_m":297829164.926983,
+    "geom:area_square_m":297829366.671957,
     "geom:bbox":"-88.562363,14.12361,-88.329811,14.367393",
     "geom:latitude":14.238592,
     "geom:longitude":-88.45626,
@@ -120,12 +120,13 @@
         "qs_pg:id":956673,
         "wd:id":"Q387445"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009351,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"42f46f12a75852ab9afb83fd56dfe08a",
+    "wof:geomhash":"e22e9b336cde1902a08dc03c2bec6f65",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421182911,
-    "wof:lastmodified":1690930341,
+    "wof:lastmodified":1695886691,
     "wof:name":"Erandique",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/913/421182913.geojson
+++ b/data/421/182/913/421182913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040473,
-    "geom:area_square_m":482763480.589254,
+    "geom:area_square_m":482763058.249993,
     "geom:bbox":"-86.665253,15.141436,-86.390816,15.406235",
     "geom:latitude":15.280887,
     "geom:longitude":-86.547311,
@@ -120,12 +120,13 @@
         "qs_pg:id":956674,
         "wd:id":"Q2393712"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8dc4cc42939196ac1410b435cd7a5864",
+    "wof:geomhash":"c2d77e349d65a93794eb244933da5475",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421182913,
-    "wof:lastmodified":1690930335,
+    "wof:lastmodified":1695886686,
     "wof:name":"Esquipulas del Norte",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/182/915/421182915.geojson
+++ b/data/421/182/915/421182915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0168,
-    "geom:area_square_m":201674255.367871,
+    "geom:area_square_m":201674306.465532,
     "geom:bbox":"-87.010445,13.778684,-86.859718,13.969032",
     "geom:latitude":13.870411,
     "geom:longitude":-86.943038,
@@ -117,12 +117,13 @@
         "qs_pg:id":956675,
         "wd:id":"Q732437"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"58e5d6ed0f79859894a8c31953b29689",
+    "wof:geomhash":"3cbdc0e53de87154d85b07bac58907e7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421182915,
-    "wof:lastmodified":1690930332,
+    "wof:lastmodified":1695886682,
     "wof:name":"Guinope",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/917/421182917.geojson
+++ b/data/421/182/917/421182917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014687,
-    "geom:area_square_m":175381429.799617,
+    "geom:area_square_m":175381629.922145,
     "geom:bbox":"-88.238464,14.992914,-88.02581,15.113304",
     "geom:latitude":15.051921,
     "geom:longitude":-88.126817,
@@ -114,12 +114,13 @@
         "qs_pg:id":956676,
         "wd:id":"Q2055833"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3dd3d3079dcf601111dd653e4e7ab18f",
+    "wof:geomhash":"9b1502837ae0a854e9e04f2787466156",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421182917,
-    "wof:lastmodified":1690930343,
+    "wof:lastmodified":1695886694,
     "wof:name":"Ilama",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/182/919/421182919.geojson
+++ b/data/421/182/919/421182919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009398,
-    "geom:area_square_m":112726427.039246,
+    "geom:area_square_m":112726513.745318,
     "geom:bbox":"-86.742111,13.961154,-86.611435,14.166986",
     "geom:latitude":14.049921,
     "geom:longitude":-86.686107,
@@ -120,12 +120,13 @@
         "qs_pg:id":956677,
         "wd:id":"Q2209633"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eb7a8c5b5e0f7add8ae72ab4e977fba8",
+    "wof:geomhash":"e088bdf8541f2b06cf96f80d0ce31110",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421182919,
-    "wof:lastmodified":1690930343,
+    "wof:lastmodified":1695886693,
     "wof:name":"Jacaleapa",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/921/421182921.geojson
+++ b/data/421/182/921/421182921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035164,
-    "geom:area_square_m":420904450.525824,
+    "geom:area_square_m":420904642.254966,
     "geom:bbox":"-88.135567,14.42312,-87.89743,14.662828",
     "geom:latitude":14.528691,
     "geom:longitude":-88.023791,
@@ -94,12 +94,13 @@
         "qs_pg:id":956678,
         "wd:id":"Q2105288"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a7c1b46ee166c21120042f0a1c4a6eee",
+    "wof:geomhash":"02eb134e145ccc41013787a0acc0dc2d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421182921,
-    "wof:lastmodified":1627522177,
+    "wof:lastmodified":1695886650,
     "wof:name":"Jesus de Otoro",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/182/923/421182923.geojson
+++ b/data/421/182/923/421182923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00908,
-    "geom:area_square_m":108716330.888305,
+    "geom:area_square_m":108716449.966899,
     "geom:bbox":"-88.635437,14.421235,-88.498085,14.53327",
     "geom:latitude":14.472817,
     "geom:longitude":-88.560687,
@@ -118,12 +118,13 @@
         "wd:id":"Q2394060",
         "wk:page":"La Campa"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7ef8fab077376aa6dbea88feaab4daad",
+    "wof:geomhash":"490abbe8caf895257d9564555d45b13b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421182923,
-    "wof:lastmodified":1690930333,
+    "wof:lastmodified":1695886684,
     "wof:name":"La Campa",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/925/421182925.geojson
+++ b/data/421/182/925/421182925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026941,
-    "geom:area_square_m":321961078.720687,
+    "geom:area_square_m":321960760.51631,
     "geom:bbox":"-87.74308,14.722327,-87.494591,15.02373",
     "geom:latitude":14.880037,
     "geom:longitude":-87.598857,
@@ -160,12 +160,13 @@
         "wd:id":"Q1986477",
         "wk:page":"La Libertad, Comayagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3c46327b39db03b40fc5b9f3aeeb8f49",
+    "wof:geomhash":"cb2dbe8425f157eb5526454325e8acc9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":421182925,
-    "wof:lastmodified":1690930335,
+    "wof:lastmodified":1695886698,
     "wof:name":"La Libertad",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/182/929/421182929.geojson
+++ b/data/421/182/929/421182929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0395,
-    "geom:area_square_m":470492425.988541,
+    "geom:area_square_m":470492180.699221,
     "geom:bbox":"-87.231522,15.420625,-87.040634,15.789508",
     "geom:latitude":15.575679,
     "geom:longitude":-87.137694,
@@ -121,12 +121,13 @@
         "wd:id":"Q2358954",
         "wk:page":"La Masica"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"93980d65d9f5c5725f16835d97f70333",
+    "wof:geomhash":"1af7bef0e8095f54052d02b8d3fd7f2f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421182929,
-    "wof:lastmodified":1690930342,
+    "wof:lastmodified":1695886692,
     "wof:name":"La Masica",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/182/931/421182931.geojson
+++ b/data/421/182/931/421182931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007164,
-    "geom:area_square_m":85643378.045006,
+    "geom:area_square_m":85643384.730612,
     "geom:bbox":"-88.488747,14.753564,-88.364349,14.857654",
     "geom:latitude":14.808026,
     "geom:longitude":-88.422366,
@@ -195,12 +195,13 @@
         "hasc:id":"HN.LE.LU",
         "qs_pg:id":956682
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3842293172e613c07ccc565059f7f67a",
+    "wof:geomhash":"a680d563cee4c4428cf8b3478b627e6e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":421182931,
-    "wof:lastmodified":1636495870,
+    "wof:lastmodified":1695886695,
     "wof:name":"La Union",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/933/421182933.geojson
+++ b/data/421/182/933/421182933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018313,
-    "geom:area_square_m":219029161.487568,
+    "geom:area_square_m":219028903.901482,
     "geom:bbox":"-89.026138,14.595056,-88.876938,14.799566",
     "geom:latitude":14.698746,
     "geom:longitude":-88.948541,
@@ -195,12 +195,13 @@
         "hasc:id":"HN.CP.LU",
         "qs_pg:id":956683
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b8d1ee1975c2b49c9075d23855499755",
+    "wof:geomhash":"197c7cf3b60c6cac89e59a1902c2254e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":421182933,
-    "wof:lastmodified":1636495874,
+    "wof:lastmodified":1695886700,
     "wof:name":"La Union",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/182/935/421182935.geojson
+++ b/data/421/182/935/421182935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010566,
-    "geom:area_square_m":126911699.155333,
+    "geom:area_square_m":126911831.935931,
     "geom:bbox":"-87.394585,13.678765,-87.258629,13.7918",
     "geom:latitude":13.732098,
     "geom:longitude":-87.327603,
@@ -124,12 +124,13 @@
         "wd:id":"Q628829",
         "wk:page":"La Venta, Francisco Moraz\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3bea359e2b9977ad6d45dbd03f878d26",
+    "wof:geomhash":"069b4839150d923b74eceb9f578cf292",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421182935,
-    "wof:lastmodified":1690930338,
+    "wof:lastmodified":1695886688,
     "wof:name":"La Venta",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/182/937/421182937.geojson
+++ b/data/421/182/937/421182937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020755,
-    "geom:area_square_m":247624938.520415,
+    "geom:area_square_m":247624809.77814,
     "geom:bbox":"-88.716782,15.14511,-88.459717,15.331765",
     "geom:latitude":15.232448,
     "geom:longitude":-88.572974,
@@ -117,12 +117,13 @@
         "qs_pg:id":956685,
         "wd:id":"Q2395223"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28aa53e03f987e506892de3917763ecc",
+    "wof:geomhash":"9b89a5d3d5ad907a976ab7dd10b1d489",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421182937,
-    "wof:lastmodified":1690930328,
+    "wof:lastmodified":1695886679,
     "wof:name":"Macuelizo",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/182/939/421182939.geojson
+++ b/data/421/182/939/421182939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04354,
-    "geom:area_square_m":520329482.147132,
+    "geom:area_square_m":520329482.146513,
     "geom:bbox":"-86.5370559692,14.7421703339,-86.2424316406,15.0113859177",
     "geom:latitude":14.876355,
     "geom:longitude":-86.397017,
@@ -128,12 +128,13 @@
         "hasc:id":"HN.OL.MT",
         "qs_pg:id":956686
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009352,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c463403ea3fb08bd10ca0ab8203c0fb0",
+    "wof:geomhash":"a1a1e80e8b7e7ceb6daf0a3a33df677c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":421182939,
-    "wof:lastmodified":1582319370,
+    "wof:lastmodified":1695886678,
     "wof:name":"Manto",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/182/941/421182941.geojson
+++ b/data/421/182/941/421182941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002719,
-    "geom:area_square_m":32612318.995907,
+    "geom:area_square_m":32612183.645096,
     "geom:bbox":"-88.656776,14.013526,-88.58493,14.086797",
     "geom:latitude":14.048719,
     "geom:longitude":-88.62152,
@@ -111,12 +111,13 @@
         "qs_pg:id":956687,
         "wd:id":"Q1645810"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f5d4b4179a97a580c8348cde9c050e8f",
+    "wof:geomhash":"f4d1e38caac1e24fc6e68616e756e90b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421182941,
-    "wof:lastmodified":1690930332,
+    "wof:lastmodified":1695886683,
     "wof:name":"Mapulaca",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/943/421182943.geojson
+++ b/data/421/182/943/421182943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022032,
-    "geom:area_square_m":264488783.150835,
+    "geom:area_square_m":264488563.192213,
     "geom:bbox":"-87.155014,13.762743,-86.980309,13.985159",
     "geom:latitude":13.867502,
     "geom:longitude":-87.05637,
@@ -120,12 +120,13 @@
         "qs_pg:id":956688,
         "wd:id":"Q2392935"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fd61813da6755cfca44fb31f4b281f1f",
+    "wof:geomhash":"58dbcf95e877df1881c88c4f399cbfec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421182943,
-    "wof:lastmodified":1690930344,
+    "wof:lastmodified":1695886694,
     "wof:name":"Maraita",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/182/947/421182947.geojson
+++ b/data/421/182/947/421182947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020204,
-    "geom:area_square_m":242376208.034505,
+    "geom:area_square_m":242376155.7014,
     "geom:bbox":"-87.95015,13.894305,-87.795807,14.185221",
     "geom:latitude":14.032812,
     "geom:longitude":-87.875815,
@@ -135,12 +135,13 @@
         "qs_pg:id":956689,
         "wd:id":"Q544482"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"27477d0caed2f2fc48c48110298fc1dc",
+    "wof:geomhash":"9cf8f6de2e0c7601a8f0247eee687e2a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421182947,
-    "wof:lastmodified":1690930334,
+    "wof:lastmodified":1695886685,
     "wof:name":"Opatoro",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/182/949/421182949.geojson
+++ b/data/421/182/949/421182949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014081,
-    "geom:area_square_m":169069444.2523,
+    "geom:area_square_m":169069505.305674,
     "geom:bbox":"-86.936447,13.748052,-86.757423,13.883216",
     "geom:latitude":13.819456,
     "geom:longitude":-86.83319,
@@ -89,12 +89,13 @@
         "hasc:id":"HN.EP.OR",
         "qs_pg:id":956692
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"871ce4d63fe34760ccad1630800975aa",
+    "wof:geomhash":"764072ce4b7a980017571269906d2e05",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421182949,
-    "wof:lastmodified":1627522180,
+    "wof:lastmodified":1695886654,
     "wof:name":"Oropoli",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/951/421182951.geojson
+++ b/data/421/182/951/421182951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027146,
-    "geom:area_square_m":326287240.422722,
+    "geom:area_square_m":326287525.410205,
     "geom:bbox":"-87.459503,13.488928,-87.183731,13.692718",
     "geom:latitude":13.579494,
     "geom:longitude":-87.317801,
@@ -120,12 +120,13 @@
         "qs_pg:id":956693,
         "wd:id":"Q2602771"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ecbe0e4c2f74484af1201816152da674",
+    "wof:geomhash":"a5e1161f278b56fe442ff74c0d9947af",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421182951,
-    "wof:lastmodified":1690930339,
+    "wof:lastmodified":1695886689,
     "wof:name":"Pespire",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/182/953/421182953.geojson
+++ b/data/421/182/953/421182953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017129,
-    "geom:area_square_m":204326104.93327,
+    "geom:area_square_m":204325575.998333,
     "geom:bbox":"-88.349869,15.186457,-88.126282,15.377888",
     "geom:latitude":15.275028,
     "geom:longitude":-88.23291,
@@ -114,12 +114,13 @@
         "qs_pg:id":956694,
         "wd:id":"Q2394913"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf99e8fd923e49f5c9595e6f849ed1c5",
+    "wof:geomhash":"c38714600bd6ec1b5f8eacc72f6b8468",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421182953,
-    "wof:lastmodified":1690930327,
+    "wof:lastmodified":1695886678,
     "wof:name":"Petoa",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/182/957/421182957.geojson
+++ b/data/421/182/957/421182957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020283,
-    "geom:area_square_m":243562758.12915,
+    "geom:area_square_m":243562758.12935,
     "geom:bbox":"-87.3818817139,13.6835746765,-87.1898117065,13.8980579376",
     "geom:latitude":13.799793,
     "geom:longitude":-87.259598,
@@ -101,12 +101,13 @@
         "hasc:id":"HN.FM.SG",
         "qs_pg:id":956696
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"728b0d6798ce25a2d552939c769b799e",
+    "wof:geomhash":"bef4b628db1a5fb3cd568ab15b7e7d54",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":421182957,
-    "wof:lastmodified":1582319382,
+    "wof:lastmodified":1695886687,
     "wof:name":"Sabanagrande",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/182/959/421182959.geojson
+++ b/data/421/182/959/421182959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028035,
-    "geom:area_square_m":335122022.172557,
+    "geom:area_square_m":335122042.282013,
     "geom:bbox":"-86.77491,14.70728,-86.514824,14.968403",
     "geom:latitude":14.821686,
     "geom:longitude":-86.636336,
@@ -121,12 +121,13 @@
         "wd:id":"Q2394865",
         "wk:page":"Salam\u00e1, Olancho"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"045ee48dda5a286152bca6c9ea1eb8e3",
+    "wof:geomhash":"011be16145c26c6404e6ccf2ddbadba6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421182959,
-    "wof:lastmodified":1690930337,
+    "wof:lastmodified":1695886688,
     "wof:name":"Salama",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/182/961/421182961.geojson
+++ b/data/421/182/961/421182961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011908,
-    "geom:area_square_m":141969740.474312,
+    "geom:area_square_m":141969841.75202,
     "geom:bbox":"-87.966263,15.3029,-87.818649,15.448944",
     "geom:latitude":15.38019,
     "geom:longitude":-87.899683,
@@ -124,12 +124,13 @@
         "wd:id":"Q1644884",
         "wk:page":"San Manuel, Cort\u00e9s"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9df523c8f6cc9cb25e76812947dcd47a",
+    "wof:geomhash":"105157bd1ce041e18b565b3524507865",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421182961,
-    "wof:lastmodified":1690930337,
+    "wof:lastmodified":1695886688,
     "wof:name":"San Manuel",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/182/965/421182965.geojson
+++ b/data/421/182/965/421182965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014178,
-    "geom:area_square_m":169807739.92881,
+    "geom:area_square_m":169807634.818124,
     "geom:bbox":"-89.072685,14.341346,-88.805687,14.47327",
     "geom:latitude":14.394498,
     "geom:longitude":-88.925051,
@@ -145,12 +145,13 @@
         "wd:id":"Q2605007",
         "wk:page":"San Marcos, Ocotepeque"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"005d01f035532200d415174a818589a3",
+    "wof:geomhash":"3ea9ff7e1d0ea23688fd489bddb1e0f4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":421182965,
-    "wof:lastmodified":1690930327,
+    "wof:lastmodified":1695886695,
     "wof:name":"San Marcos",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/182/967/421182967.geojson
+++ b/data/421/182/967/421182967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017441,
-    "geom:area_square_m":209273967.529949,
+    "geom:area_square_m":209274033.28257,
     "geom:bbox":"-88.026802,13.871284,-87.873772,14.121787",
     "geom:latitude":13.984801,
     "geom:longitude":-87.947929,
@@ -172,12 +172,13 @@
         "wd:id":"Q955784",
         "wk:page":"Santa Ana, La Paz"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"703530c67f102c7573c04f9a2fa0885a",
+    "wof:geomhash":"dc02ae7181f7d4109eb698858147e212",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":421182967,
-    "wof:lastmodified":1690930339,
+    "wof:lastmodified":1695886699,
     "wof:name":"Santa Ana",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/182/969/421182969.geojson
+++ b/data/421/182/969/421182969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012682,
-    "geom:area_square_m":151929719.34746,
+    "geom:area_square_m":151929729.090757,
     "geom:bbox":"-88.642601,14.283419,-88.449852,14.442683",
     "geom:latitude":14.347393,
     "geom:longitude":-88.535904,
@@ -241,12 +241,13 @@
         "hasc:id":"HN.LE.SC",
         "qs_pg:id":956701
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d19526822fa0b218be208a78afcdc628",
+    "wof:geomhash":"71c3fe6a98ee4453f141f27032d1098a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -256,7 +257,7 @@
         }
     ],
     "wof:id":421182969,
-    "wof:lastmodified":1636495874,
+    "wof:lastmodified":1695886700,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/182/971/421182971.geojson
+++ b/data/421/182/971/421182971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010849,
-    "geom:area_square_m":129456566.076736,
+    "geom:area_square_m":129456337.264792,
     "geom:bbox":"-87.924576,15.134562,-87.725243,15.237883",
     "geom:latitude":15.193106,
     "geom:longitude":-87.812801,
@@ -200,12 +200,13 @@
         "hasc:id":"HN.YO.SR",
         "qs_pg:id":956702
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009353,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ac611e056733dd5c59653c1686064463",
+    "wof:geomhash":"960678df469c8d32dd6d609282e9e43f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -215,7 +216,7 @@
         }
     ],
     "wof:id":421182971,
-    "wof:lastmodified":1636495872,
+    "wof:lastmodified":1695886699,
     "wof:name":"Santa Rita",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/182/973/421182973.geojson
+++ b/data/421/182/973/421182973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011489,
-    "geom:area_square_m":136627931.813753,
+    "geom:area_square_m":136628012.892822,
     "geom:bbox":"-85.748901,15.83532,-85.609901,15.970911",
     "geom:latitude":15.902854,
     "geom:longitude":-85.689501,
@@ -97,12 +97,13 @@
         "qs_pg:id":956703,
         "wd:id":"Q958080"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009354,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"48c9fb3ad4455866ddf8a8f40c871996",
+    "wof:geomhash":"6757736d228922d58d7a7298157bed9b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":421182973,
-    "wof:lastmodified":1627522186,
+    "wof:lastmodified":1695886665,
     "wof:name":"Sta. Rosa de Aguan",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/182/975/421182975.geojson
+++ b/data/421/182/975/421182975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011792,
-    "geom:area_square_m":141259289.138116,
+    "geom:area_square_m":141259035.159857,
     "geom:bbox":"-87.961769,14.271905,-87.789078,14.426847",
     "geom:latitude":14.358355,
     "geom:longitude":-87.879445,
@@ -115,12 +115,13 @@
         "qs_pg:id":956704,
         "wd:id":"Q1930019"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009354,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9070b24915615297d11054e83d0537eb",
+    "wof:geomhash":"d619033b4c48b3293bdb404e317998f1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421182975,
-    "wof:lastmodified":1627522187,
+    "wof:lastmodified":1695886666,
     "wof:name":"Santiago de Puringla",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/182/977/421182977.geojson
+++ b/data/421/182/977/421182977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009987,
-    "geom:area_square_m":119551639.131142,
+    "geom:area_square_m":119551661.982414,
     "geom:bbox":"-89.004295,14.446369,-88.846558,14.617702",
     "geom:latitude":14.504863,
     "geom:longitude":-88.927634,
@@ -114,12 +114,13 @@
         "qs_pg:id":956705,
         "wd:id":"Q582892"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009354,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"88c709ef5ce43cb8183ef2a7aba48922",
+    "wof:geomhash":"4b4186e6b05b96518d2b0041b5072e6f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421182977,
-    "wof:lastmodified":1690930330,
+    "wof:lastmodified":1695886680,
     "wof:name":"Senseti",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/182/979/421182979.geojson
+++ b/data/421/182/979/421182979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056017,
-    "geom:area_square_m":671207273.607065,
+    "geom:area_square_m":671207412.469643,
     "geom:bbox":"-86.831062,14.141731,-86.444557,14.422551",
     "geom:latitude":14.295241,
     "geom:longitude":-86.67905,
@@ -117,12 +117,13 @@
         "qs_pg:id":956706,
         "wd:id":"Q2392411"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009354,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"38cd6bf02402a4bcd705125f9abc2292",
+    "wof:geomhash":"c44004d247fc8792ab1eb2d344aeab5f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421182979,
-    "wof:lastmodified":1690930332,
+    "wof:lastmodified":1695886682,
     "wof:name":"Teupasenti",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/983/421182983.geojson
+++ b/data/421/182/983/421182983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015581,
-    "geom:area_square_m":187206768.684429,
+    "geom:area_square_m":187206795.566855,
     "geom:bbox":"-87.131622,13.580715,-86.931992,13.747345",
     "geom:latitude":13.669273,
     "geom:longitude":-87.038643,
@@ -118,12 +118,13 @@
         "wd:id":"Q2126741",
         "wk:page":"Texiguat"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009354,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f60fcd338ed98f79fa762a88c8e9aa09",
+    "wof:geomhash":"852be04644a2324e569adbed263bed61",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421182983,
-    "wof:lastmodified":1690930331,
+    "wof:lastmodified":1695886681,
     "wof:name":"Texigua",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/182/985/421182985.geojson
+++ b/data/421/182/985/421182985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074842,
-    "geom:area_square_m":891415714.266851,
+    "geom:area_square_m":891415754.418271,
     "geom:bbox":"-86.140747,15.386014,-85.784904,15.771691",
     "geom:latitude":15.583893,
     "geom:longitude":-85.963161,
@@ -95,12 +95,13 @@
         "hasc:id":"HN.CL.TO",
         "qs_pg:id":956708
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009354,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e581f0b9888be25c4bd62a93571fb6a3",
+    "wof:geomhash":"43d213cb50f97d779fc5857750b7022b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":421182985,
-    "wof:lastmodified":1627522187,
+    "wof:lastmodified":1695886666,
     "wof:name":"Tocoa",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/183/141/421183141.geojson
+++ b/data/421/183/141/421183141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004311,
-    "geom:area_square_m":51736897.568096,
+    "geom:area_square_m":51736749.487008,
     "geom:bbox":"-87.785614,13.92516,-87.679649,13.987598",
     "geom:latitude":13.955465,
     "geom:longitude":-87.732392,
@@ -139,12 +139,13 @@
         "wd:id":"Q1645752",
         "wk:page":"San Juan, La Paz"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009359,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"87cb38cf92a4ebe73217472064a7a3c2",
+    "wof:geomhash":"28edb11eb75f5a1e9f41bf351c2888ac",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":421183141,
-    "wof:lastmodified":1690930316,
+    "wof:lastmodified":1695886695,
     "wof:name":"San Juan",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/183/293/421183293.geojson
+++ b/data/421/183/293/421183293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019715,
-    "geom:area_square_m":235504805.666496,
+    "geom:area_square_m":235505233.83296,
     "geom:bbox":"-87.390686,14.875575,-87.184212,15.044827",
     "geom:latitude":14.972486,
     "geom:longitude":-87.278599,
@@ -120,12 +120,13 @@
         "qs_pg:id":971550,
         "wd:id":"Q727616"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009364,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9fa08d7b34c333314857ae7e28a3004c",
+    "wof:geomhash":"bb926482e9214e592ad58554c9cfb5ca",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421183293,
-    "wof:lastmodified":1690930314,
+    "wof:lastmodified":1695886673,
     "wof:name":"Sulaco",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/183/297/421183297.geojson
+++ b/data/421/183/297/421183297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016433,
-    "geom:area_square_m":196344614.519881,
+    "geom:area_square_m":196344954.630546,
     "geom:bbox":"-88.610352,14.811554,-88.405739,15.006889",
     "geom:latitude":14.919041,
     "geom:longitude":-88.498648,
@@ -114,12 +114,13 @@
         "qs_pg:id":971541,
         "wd:id":"Q601725"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009364,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"296c3f417f4caa06f2c6df1d0f517450",
+    "wof:geomhash":"6584a63ec8c0bf2ee11be8149a5e1b1b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421183297,
-    "wof:lastmodified":1690930315,
+    "wof:lastmodified":1695886674,
     "wof:name":"Atima",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/183/299/421183299.geojson
+++ b/data/421/183/299/421183299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016781,
-    "geom:area_square_m":200078889.055159,
+    "geom:area_square_m":200078596.336269,
     "geom:bbox":"-88.682083,15.297286,-88.484146,15.461793",
     "geom:latitude":15.366037,
     "geom:longitude":-88.575269,
@@ -117,12 +117,13 @@
         "qs_pg:id":971542,
         "wd:id":"Q935031"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009364,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"496a0b023f3c40d32de68c7be2a788c6",
+    "wof:geomhash":"8c0044e873f734418de002ac7708d98c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421183299,
-    "wof:lastmodified":1690930315,
+    "wof:lastmodified":1695886674,
     "wof:name":"Azacualpa",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/183/301/421183301.geojson
+++ b/data/421/183/301/421183301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009755,
-    "geom:area_square_m":116771353.039379,
+    "geom:area_square_m":116771489.753518,
     "geom:bbox":"-89.26416,14.4519,-89.130096,14.584721",
     "geom:latitude":14.525246,
     "geom:longitude":-89.203092,
@@ -118,12 +118,13 @@
         "wd:id":"Q2066939",
         "wk:page":"Concepci\u00f3n, Ocotepeque"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009364,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"482b6fbc0aeed9e597d0878c817289b4",
+    "wof:geomhash":"173bcb1ec5ba60d7403b90911348c6e3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421183301,
-    "wof:lastmodified":1690930313,
+    "wof:lastmodified":1695886673,
     "wof:name":"Concepcion",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/183/303/421183303.geojson
+++ b/data/421/183/303/421183303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015098,
-    "geom:area_square_m":180984774.057457,
+    "geom:area_square_m":180984921.128771,
     "geom:bbox":"-88.952759,14.103732,-88.744583,14.302105",
     "geom:latitude":14.207895,
     "geom:longitude":-88.842134,
@@ -114,12 +114,13 @@
         "qs_pg:id":971547,
         "wd:id":"Q1645769"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009364,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5729df543b2246ac2b3ecc0e125b3ccd",
+    "wof:geomhash":"f47f760c3f57bb0db95bdee7edee0dae",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421183303,
-    "wof:lastmodified":1690930314,
+    "wof:lastmodified":1695886674,
     "wof:name":"Guarita",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/183/307/421183307.geojson
+++ b/data/421/183/307/421183307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033966,
-    "geom:area_square_m":404468706.697399,
+    "geom:area_square_m":404468856.119166,
     "geom:bbox":"-86.407516,15.531565,-86.09716,15.732731",
     "geom:latitude":15.630389,
     "geom:longitude":-86.25673,
@@ -129,12 +129,13 @@
         "qs_pg:id":971549,
         "wd:id":"Q1020581"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009365,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"16986b9a14a03689b72eb30eaaf6ce27",
+    "wof:geomhash":"de9a84a35b98b482249e3251e393fc06",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421183307,
-    "wof:lastmodified":1690930313,
+    "wof:lastmodified":1695886672,
     "wof:name":"Sonaguera",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/183/317/421183317.geojson
+++ b/data/421/183/317/421183317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018285,
-    "geom:area_square_m":219241482.64892,
+    "geom:area_square_m":219241588.060336,
     "geom:bbox":"-88.118523,13.994319,-87.943069,14.254082",
     "geom:latitude":14.145984,
     "geom:longitude":-88.037254,
@@ -136,12 +136,13 @@
         "wd:id":"Q2331621",
         "wk:page":"Marcala"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009365,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a74e4c5e44eabb090b629aea43079b05",
+    "wof:geomhash":"4b8481074ea94a1eb5992ad6011f0796",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":421183317,
-    "wof:lastmodified":1690930316,
+    "wof:lastmodified":1695886675,
     "wof:name":"Marcala",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/183/319/421183319.geojson
+++ b/data/421/183/319/421183319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031589,
-    "geom:area_square_m":377887570.476327,
+    "geom:area_square_m":377887964.952838,
     "geom:bbox":"-88.54895,14.538343,-88.323196,14.830255",
     "geom:latitude":14.66028,
     "geom:longitude":-88.453473,
@@ -117,12 +117,13 @@
         "qs_pg:id":972358,
         "wd:id":"Q2394093"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009365,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"22160797665bb2c4bcdc901f91bd71ce",
+    "wof:geomhash":"c1f8e741c6799168a9e4053e6bda7915",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421183319,
-    "wof:lastmodified":1690930316,
+    "wof:lastmodified":1695886676,
     "wof:name":"La Iguala",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/183/321/421183321.geojson
+++ b/data/421/183/321/421183321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019113,
-    "geom:area_square_m":228658088.075409,
+    "geom:area_square_m":228658089.982179,
     "geom:bbox":"-87.636696,14.56601,-87.470573,14.729274",
     "geom:latitude":14.640383,
     "geom:longitude":-87.55803,
@@ -121,12 +121,13 @@
         "wd:id":"Q427781",
         "wk:page":"San Jer\u00f3nimo, Comayagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009365,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2ffeb586de7a8995a1e9d3994eaad37f",
+    "wof:geomhash":"641347b6ec0d0a10b38227686eeaefb1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421183321,
-    "wof:lastmodified":1690930317,
+    "wof:lastmodified":1695886676,
     "wof:name":"San Jeronimo",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/183/865/421183865.geojson
+++ b/data/421/183/865/421183865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002381,
-    "geom:area_square_m":28459055.713756,
+    "geom:area_square_m":28459047.845133,
     "geom:bbox":"-88.876564,14.823344,-88.800392,14.907453",
     "geom:latitude":14.867844,
     "geom:longitude":-88.840761,
@@ -118,12 +118,13 @@
         "wd:id":"Q2392425",
         "wk:page":"Dulce Nombre"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009389,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7811be201279cbc8e9f95be1441ead10",
+    "wof:geomhash":"879d2cae80dee1c3b3c83bd67438ffdc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421183865,
-    "wof:lastmodified":1690930315,
+    "wof:lastmodified":1695886675,
     "wof:name":"Dulce Nombre",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/184/149/421184149.geojson
+++ b/data/421/184/149/421184149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017689,
-    "geom:area_square_m":212199346.780178,
+    "geom:area_square_m":212199503.323152,
     "geom:bbox":"-87.105377,13.950429,-86.910194,14.125035",
     "geom:latitude":14.034443,
     "geom:longitude":-86.990137,
@@ -91,12 +91,13 @@
         "qs_pg:id":989528,
         "wd:id":"Q1834215"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009402,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7c3242b20a31fb6f95d69ea2af3b8945",
+    "wof:geomhash":"6a9857895fda16187bd85a15d5139ac4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421184149,
-    "wof:lastmodified":1627522181,
+    "wof:lastmodified":1695886656,
     "wof:name":"San Antonio de Oriente",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/184/345/421184345.geojson
+++ b/data/421/184/345/421184345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006132,
-    "geom:area_square_m":73282841.728277,
+    "geom:area_square_m":73282862.609491,
     "geom:bbox":"-88.959846,14.794275,-88.80899,14.934525",
     "geom:latitude":14.871033,
     "geom:longitude":-88.885758,
@@ -90,12 +90,13 @@
         "hasc:id":"HN.CP.CN",
         "qs_pg:id":995486
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009408,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"09ed6c8fcd2645de3268c83bc142a40a",
+    "wof:geomhash":"5c0cbec37f8cc2819fa5950ffeb114b0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421184345,
-    "wof:lastmodified":1627522173,
+    "wof:lastmodified":1695886641,
     "wof:name":"Concepcion",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/184/463/421184463.geojson
+++ b/data/421/184/463/421184463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006566,
-    "geom:area_square_m":78711403.194818,
+    "geom:area_square_m":78711398.037187,
     "geom:bbox":"-87.007118,14.144834,-86.896614,14.238566",
     "geom:latitude":14.197668,
     "geom:longitude":-86.951232,
@@ -91,12 +91,13 @@
         "qs_pg:id":999087,
         "wd:id":"Q2393148"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009411,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5e46153eb5958a9910adce0fe0cc21a9",
+    "wof:geomhash":"c873e9d6b54992f872fe2abd4ea7b115",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421184463,
-    "wof:lastmodified":1627522188,
+    "wof:lastmodified":1695886668,
     "wof:name":"Villa de San Francisco",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/184/465/421184465.geojson
+++ b/data/421/184/465/421184465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029411,
-    "geom:area_square_m":350726691.234841,
+    "geom:area_square_m":350726691.235385,
     "geom:bbox":"-88.1462860107,15.2102079391,-87.9458312988,15.4339475632",
     "geom:latitude":15.330677,
     "geom:longitude":-88.047423,
@@ -116,12 +116,13 @@
         "hasc:id":"HN.CR.VI",
         "qs_pg:id":999088
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009411,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"886d99602a364eb9e35ae84f5f0cfa9b",
+    "wof:geomhash":"ae5a03a08c9578ccb8b0a251d3a9450e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421184465,
-    "wof:lastmodified":1582319349,
+    "wof:lastmodified":1695886662,
     "wof:name":"Villa Nueva",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/184/595/421184595.geojson
+++ b/data/421/184/595/421184595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007994,
-    "geom:area_square_m":95937930.849956,
+    "geom:area_square_m":95938110.760459,
     "geom:bbox":"-87.290421,13.871591,-87.123734,13.978772",
     "geom:latitude":13.928103,
     "geom:longitude":-87.214069,
@@ -157,12 +157,13 @@
         "wd:id":"Q1645164",
         "wk:page":"Santa Ana, Francisco Moraz\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009416,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5000092d26d9e20573ce0a5cad4ecaa2",
+    "wof:geomhash":"e608c454e36e6688d1cacfeea417505b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":421184595,
-    "wof:lastmodified":1690930306,
+    "wof:lastmodified":1695886695,
     "wof:name":"Santa Ana",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/184/597/421184597.geojson
+++ b/data/421/184/597/421184597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028686,
-    "geom:area_square_m":343707933.02195,
+    "geom:area_square_m":343707863.707628,
     "geom:bbox":"-87.647346,14.201948,-87.391266,14.389887",
     "geom:latitude":14.302881,
     "geom:longitude":-87.529195,
@@ -91,12 +91,13 @@
         "qs_pg:id":1002135,
         "wd:id":"Q2257820"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009416,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"84911d7b343e0d893cd351692abd517a",
+    "wof:geomhash":"d4575576f1a454c27ea63d10d288c6fc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421184597,
-    "wof:lastmodified":1627522188,
+    "wof:lastmodified":1695886668,
     "wof:name":"Villa de San Antonio",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/185/031/421185031.geojson
+++ b/data/421/185/031/421185031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016669,
-    "geom:area_square_m":199532976.603288,
+    "geom:area_square_m":199532724.332477,
     "geom:bbox":"-88.537949,14.453444,-88.330597,14.595359",
     "geom:latitude":14.524103,
     "geom:longitude":-88.430981,
@@ -163,12 +163,13 @@
         "wd:id":"Q2355084",
         "wk:page":"Bel\u00e9n, Honduras"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009430,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"743e05fc0b6a133262cfbcb3882fa9e4",
+    "wof:geomhash":"0cc79112110c36ed642f4dfba72db44e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":421185031,
-    "wof:lastmodified":1690930347,
+    "wof:lastmodified":1695886703,
     "wof:name":"Belen",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/185/035/421185035.geojson
+++ b/data/421/185/035/421185035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039357,
-    "geom:area_square_m":468629374.091926,
+    "geom:area_square_m":468629784.212966,
     "geom:bbox":"-88.091141,15.539175,-87.77169,15.758631",
     "geom:latitude":15.643523,
     "geom:longitude":-87.934017,
@@ -216,12 +216,13 @@
         "wd:id":"Q998218",
         "wk:page":"Choloma"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009430,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd70594968a03938d79e7fc59965e65c",
+    "wof:geomhash":"fae161161f07a94005d75153f46aa2a3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -231,7 +232,7 @@
         }
     ],
     "wof:id":421185035,
-    "wof:lastmodified":1690930348,
+    "wof:lastmodified":1695886694,
     "wof:name":"Choloma",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/185/037/421185037.geojson
+++ b/data/421/185/037/421185037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020778,
-    "geom:area_square_m":250030271.742439,
+    "geom:area_square_m":250030327.83621,
     "geom:bbox":"-87.101639,13.173804,-86.915947,13.403879",
     "geom:latitude":13.303499,
     "geom:longitude":-87.016401,
@@ -121,12 +121,13 @@
         "wd:id":"Q2311788",
         "wk:page":"El Corpus"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009430,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f35d38bc4d1768cd6663685016ff239f",
+    "wof:geomhash":"5b38b345517463b31fc4bb47982b2aed",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421185037,
-    "wof:lastmodified":1690930347,
+    "wof:lastmodified":1695886694,
     "wof:name":"El Corpus",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/185/397/421185397.geojson
+++ b/data/421/185/397/421185397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.190633,
-    "geom:area_square_m":2274281890.371233,
+    "geom:area_square_m":2274283050.719977,
     "geom:bbox":"-87.562485,15.015387,-86.855835,15.546222",
     "geom:latitude":15.243301,
     "geom:longitude":-87.22755,
@@ -136,12 +136,13 @@
         "hasc:id":"HN.YO.YO",
         "qs_pg:id":1024213
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009442,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0980cec0b3b1a77911d576b416a2cfdb",
+    "wof:geomhash":"28270f17f264763d3877819b75c1d884",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":421185397,
-    "wof:lastmodified":1636495875,
+    "wof:lastmodified":1695886701,
     "wof:name":"Yoro",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/186/027/421186027.geojson
+++ b/data/421/186/027/421186027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015032,
-    "geom:area_square_m":180017774.555247,
+    "geom:area_square_m":180017728.516908,
     "geom:bbox":"-88.503265,14.348065,-88.333656,14.480066",
     "geom:latitude":14.420841,
     "geom:longitude":-88.423057,
@@ -151,12 +151,13 @@
         "wd:id":"Q979141",
         "wk:page":"San Juan, Intibuc\u00e1"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009462,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0e67461c2572cd8667f309a914469068",
+    "wof:geomhash":"a83083bc8495cb870670196b7221d1df",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":421186027,
-    "wof:lastmodified":1690930275,
+    "wof:lastmodified":1695886679,
     "wof:name":"San Juan",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/186/029/421186029.geojson
+++ b/data/421/186/029/421186029.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014661,
-    "geom:area_square_m":175552724.391914,
+    "geom:area_square_m":175552634.079706,
     "geom:bbox":"-88.739708,14.367523,-88.603058,14.523132",
     "geom:latitude":14.451223,
     "geom:longitude":-88.669959,
@@ -89,12 +89,13 @@
         "hasc:id":"HN.LE.SH",
         "qs_pg:id":908158
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009462,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"289f6a7ae8eae645400f0bf6d37a76b5",
+    "wof:geomhash":"ad7ad4b912799c2420e3f39cc6cd979f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421186029,
-    "wof:lastmodified":1627522184,
+    "wof:lastmodified":1695886660,
     "wof:name":"San Manuel de Colohete",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/188/477/421188477.geojson
+++ b/data/421/188/477/421188477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017497,
-    "geom:area_square_m":208909118.734691,
+    "geom:area_square_m":208908950.989874,
     "geom:bbox":"-87.405045,15.012268,-87.15567,15.145463",
     "geom:latitude":15.074293,
     "geom:longitude":-87.304783,
@@ -114,12 +114,13 @@
         "qs_pg:id":1097332,
         "wd:id":"Q1647584"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009560,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b929b4382786f2a653083ef38457ade7",
+    "wof:geomhash":"fbce534762730333816a1a0efc858429",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421188477,
-    "wof:lastmodified":1690930262,
+    "wof:lastmodified":1695886620,
     "wof:name":"Yorito",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/188/479/421188479.geojson
+++ b/data/421/188/479/421188479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028758,
-    "geom:area_square_m":343214537.479164,
+    "geom:area_square_m":343214537.477196,
     "geom:bbox":"-88.9423294067,14.9854679108,-88.6995239258,15.2949304581",
     "geom:latitude":15.167319,
     "geom:longitude":-88.816703,
@@ -598,12 +598,13 @@
         "hasc:id":"HN.CP.FL",
         "qs_pg:id":1097268
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009560,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"63aa6eadb768c671e65a2fb1ee044823",
+    "wof:geomhash":"0c456c83cce4a6b60ae4e66a03fa2157",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -613,7 +614,7 @@
         }
     ],
     "wof:id":421188479,
-    "wof:lastmodified":1582319291,
+    "wof:lastmodified":1695886621,
     "wof:name":"Florida",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/188/481/421188481.geojson
+++ b/data/421/188/481/421188481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007757,
-    "geom:area_square_m":92822715.082753,
+    "geom:area_square_m":92822755.303651,
     "geom:bbox":"-89.121681,14.518858,-89.019386,14.649294",
     "geom:latitude":14.584682,
     "geom:longitude":-89.072594,
@@ -118,12 +118,13 @@
         "wd:id":"Q945066",
         "wk:page":"Fraternidad, Ocotepeque"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009560,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e6966e3744b9e116db2e797d8f411705",
+    "wof:geomhash":"7626f2f8bfe9e4538316b690952a791b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421188481,
-    "wof:lastmodified":1690930267,
+    "wof:lastmodified":1695886627,
     "wof:name":"Fraternidad",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/188/483/421188483.geojson
+++ b/data/421/188/483/421188483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065471,
-    "geom:area_square_m":783727381.253551,
+    "geom:area_square_m":783727276.010116,
     "geom:bbox":"-87.037842,14.318689,-86.710648,14.660658",
     "geom:latitude":14.513256,
     "geom:longitude":-86.867795,
@@ -88,12 +88,13 @@
         "hasc:id":"HN.FM.GU",
         "qs_pg:id":1097270
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009560,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e001bb3f260edd6f98c33339888e387a",
+    "wof:geomhash":"e4bc665adb771e3b74755972a27d4fd6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421188483,
-    "wof:lastmodified":1627522176,
+    "wof:lastmodified":1695886646,
     "wof:name":"Guimaca",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/188/485/421188485.geojson
+++ b/data/421/188/485/421188485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009951,
-    "geom:area_square_m":119080423.203287,
+    "geom:area_square_m":119080423.203364,
     "geom:bbox":"-89.0585250854,14.5325336456,-88.9071350098,14.6581993103",
     "geom:latitude":14.592701,
     "geom:longitude":-88.983596,
@@ -137,12 +137,13 @@
         "hasc:id":"HN.OC.LU",
         "qs_pg:id":1097289
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009560,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1dc75e98279b1125d51053a984711ca",
+    "wof:geomhash":"745c3a18c55388851a9148e9a38a6120",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421188485,
-    "wof:lastmodified":1582319289,
+    "wof:lastmodified":1695886619,
     "wof:name":"Lucerna",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/188/487/421188487.geojson
+++ b/data/421/188/487/421188487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029086,
-    "geom:area_square_m":348843225.144827,
+    "geom:area_square_m":348843288.737707,
     "geom:bbox":"-87.883888,13.97291,-87.684837,14.212909",
     "geom:latitude":14.080426,
     "geom:longitude":-87.786058,
@@ -123,12 +123,13 @@
         "qs_pg:id":1097274,
         "wd:id":"Q2160059"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009561,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"255fa360fe5aac90317c9247868a7836",
+    "wof:geomhash":"6a8024913154c2c11b62f2da508c8d02",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421188487,
-    "wof:lastmodified":1690930267,
+    "wof:lastmodified":1695886628,
     "wof:name":"Guajiquiro",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/188/491/421188491.geojson
+++ b/data/421/188/491/421188491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187272,
-    "geom:area_square_m":2234709156.285192,
+    "geom:area_square_m":2234709086.529164,
     "geom:bbox":"-86.356796,14.920992,-85.771774,15.529252",
     "geom:latitude":15.193699,
     "geom:longitude":-86.078552,
@@ -117,12 +117,13 @@
         "qs_pg:id":1097275,
         "wd:id":"Q2394350"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009561,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"471af54c2b469c64a6ea0035cb3aea39",
+    "wof:geomhash":"ef97d8ed73f9f42818acdebdeb039699",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421188491,
-    "wof:lastmodified":1690930263,
+    "wof:lastmodified":1695886622,
     "wof:name":"Gualaco",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/188/495/421188495.geojson
+++ b/data/421/188/495/421188495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008635,
-    "geom:area_square_m":103370865.60984,
+    "geom:area_square_m":103370769.1202,
     "geom:bbox":"-89.086014,14.434654,-88.968796,14.556481",
     "geom:latitude":14.495258,
     "geom:longitude":-89.033425,
@@ -114,12 +114,13 @@
         "qs_pg:id":1097277,
         "wd:id":"Q2393997"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009561,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f0f495907ef2cc2563cc420ebdf7569a",
+    "wof:geomhash":"681de19b03d18403019b0c2712f3e81d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421188495,
-    "wof:lastmodified":1690930268,
+    "wof:lastmodified":1695886628,
     "wof:name":"La Labor",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/188/497/421188497.geojson
+++ b/data/421/188/497/421188497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011845,
-    "geom:area_square_m":141958826.772578,
+    "geom:area_square_m":141958957.875544,
     "geom:bbox":"-88.218369,14.1602,-88.05645,14.313132",
     "geom:latitude":14.250198,
     "geom:longitude":-88.13339,
@@ -125,12 +125,13 @@
         "hasc:id":"HN.IN.LE",
         "qs_pg:id":1097278
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009561,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b0e9ddf6ee227fb4de7cf26a237e3b18",
+    "wof:geomhash":"b6cb8f2a476b47d1399ab54da7a8de47",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421188497,
-    "wof:lastmodified":1636495851,
+    "wof:lastmodified":1695886674,
     "wof:name":"La Esperanza",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/188/501/421188501.geojson
+++ b/data/421/188/501/421188501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032997,
-    "geom:area_square_m":394305894.040605,
+    "geom:area_square_m":394305775.384037,
     "geom:bbox":"-87.597641,14.734795,-87.248787,15.056875",
     "geom:latitude":14.892449,
     "geom:longitude":-87.453788,
@@ -94,12 +94,13 @@
         "qs_pg:id":1097291,
         "wd:id":"Q2116913"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009561,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa64391642d1381a0ff721758a288d75",
+    "wof:geomhash":"ab43d0b2b9cba5ec16696ded10a64850",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421188501,
-    "wof:lastmodified":1627522179,
+    "wof:lastmodified":1695886652,
     "wof:name":"Minas de Oro",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/188/503/421188503.geojson
+++ b/data/421/188/503/421188503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018087,
-    "geom:area_square_m":217770443.431588,
+    "geom:area_square_m":217770348.806811,
     "geom:bbox":"-87.220085,13.039319,-87.072861,13.263126",
     "geom:latitude":13.160247,
     "geom:longitude":-87.1349,
@@ -117,12 +117,13 @@
         "qs_pg:id":1097292,
         "wd:id":"Q2602518"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009561,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"00b3c163eb4b33fe147070a12a53d021",
+    "wof:geomhash":"826ac597685e7486af81de581b6ea07f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421188503,
-    "wof:lastmodified":1690930262,
+    "wof:lastmodified":1695886620,
     "wof:name":"Namasigue",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/188/505/421188505.geojson
+++ b/data/421/188/505/421188505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007462,
-    "geom:area_square_m":89698799.987355,
+    "geom:area_square_m":89698727.599753,
     "geom:bbox":"-87.113197,13.501615,-86.999611,13.601064",
     "geom:latitude":13.553689,
     "geom:longitude":-87.05997,
@@ -117,12 +117,13 @@
         "qs_pg:id":1097293,
         "wd:id":"Q1948279"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009561,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"06f9ede230b5de58c9d0d0e28c4a86d5",
+    "wof:geomhash":"c06b92c0404dcf085b88e4378e2b43cb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421188505,
-    "wof:lastmodified":1690930261,
+    "wof:lastmodified":1695886617,
     "wof:name":"Liure",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/188/509/421188509.geojson
+++ b/data/421/188/509/421188509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01175,
-    "geom:area_square_m":140362930.304579,
+    "geom:area_square_m":140362919.346363,
     "geom:bbox":"-88.704071,14.912855,-88.540474,15.037943",
     "geom:latitude":14.972335,
     "geom:longitude":-88.626055,
@@ -116,12 +116,13 @@
         "hasc:id":"HN.SB.NA",
         "qs_pg:id":1097294
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009561,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9c7268d1f794d817ac9fe53e405b3793",
+    "wof:geomhash":"75dd00a4fdea700ea39d4013836b434d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421188509,
-    "wof:lastmodified":1627522180,
+    "wof:lastmodified":1695886654,
     "wof:name":"Naranjito",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/188/511/421188511.geojson
+++ b/data/421/188/511/421188511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005832,
-    "geom:area_square_m":69714387.676779,
+    "geom:area_square_m":69714459.365837,
     "geom:bbox":"-88.980949,14.747224,-88.895218,14.872013",
     "geom:latitude":14.815211,
     "geom:longitude":-88.930525,
@@ -127,12 +127,13 @@
         "wd:id":"Q2119638",
         "wk:page":"San Agust\u00edn, Cop\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009561,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"16b651630d335e6fcbf27cff65300d1a",
+    "wof:geomhash":"46655e7d5582751061145872b34367dc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421188511,
-    "wof:lastmodified":1690930266,
+    "wof:lastmodified":1695886626,
     "wof:name":"San Agustin",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/188/513/421188513.geojson
+++ b/data/421/188/513/421188513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020672,
-    "geom:area_square_m":247766314.961181,
+    "geom:area_square_m":247766314.961215,
     "geom:bbox":"-88.6954498291,14.1403102875,-88.5164642334,14.3365316391",
     "geom:latitude":14.231081,
     "geom:longitude":-88.613546,
@@ -117,12 +117,13 @@
         "hasc:id":"HN.LE.SA",
         "qs_pg:id":1097302
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009561,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"528c92504a46c3a9c4881584e21f587f",
+    "wof:geomhash":"968431978cc17a564a2e69a5dc8d5452",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421188513,
-    "wof:lastmodified":1582319305,
+    "wof:lastmodified":1695886633,
     "wof:name":"San Andres",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/188/515/421188515.geojson
+++ b/data/421/188/515/421188515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018598,
-    "geom:area_square_m":221993982.960668,
+    "geom:area_square_m":221993942.529073,
     "geom:bbox":"-88.120705,15.047294,-87.9338,15.234708",
     "geom:latitude":15.131069,
     "geom:longitude":-88.027649,
@@ -91,12 +91,13 @@
         "qs_pg:id":1097303,
         "wd:id":"Q967937"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009565,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ef2eee98c84b7c1a904082f73ce0a8f6",
+    "wof:geomhash":"1812075ec6f2a5743b5b21ef99bc2173",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421188515,
-    "wof:lastmodified":1627522180,
+    "wof:lastmodified":1695886655,
     "wof:name":"San Antonio de Cortes",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/188/519/421188519.geojson
+++ b/data/421/188/519/421188519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003981,
-    "geom:area_square_m":47709058.694941,
+    "geom:area_square_m":47709073.334603,
     "geom:bbox":"-87.882271,14.195557,-87.819771,14.297941",
     "geom:latitude":14.248332,
     "geom:longitude":-87.850638,
@@ -97,12 +97,13 @@
         "qs_pg:id":1097318,
         "wd:id":"Q2201661"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009565,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ebaac3931a0368303f6bf2dfc820925b",
+    "wof:geomhash":"ea74fd3e8ee57c2f40b7371f9a6f1fd2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":421188519,
-    "wof:lastmodified":1627522185,
+    "wof:lastmodified":1695886663,
     "wof:name":"San Pedro Tutule",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/188/521/421188521.geojson
+++ b/data/421/188/521/421188521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017623,
-    "geom:area_square_m":210732014.302683,
+    "geom:area_square_m":210731944.916168,
     "geom:bbox":"-88.165154,14.642249,-87.98111,14.881539",
     "geom:latitude":14.746667,
     "geom:longitude":-88.09274,
@@ -114,12 +114,13 @@
         "qs_pg:id":1097319,
         "wd:id":"Q2394316"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009565,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c4b418abcb4578c787f42660ec047d75",
+    "wof:geomhash":"816e8952739775a1caf9caba245701a2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421188521,
-    "wof:lastmodified":1690930264,
+    "wof:lastmodified":1695886623,
     "wof:name":"San Pedro Zacapa",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/188/523/421188523.geojson
+++ b/data/421/188/523/421188523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003719,
-    "geom:area_square_m":44569351.090083,
+    "geom:area_square_m":44569467.230077,
     "geom:bbox":"-87.68721,14.19486,-87.588593,14.2689",
     "geom:latitude":14.237697,
     "geom:longitude":-87.637876,
@@ -121,12 +121,13 @@
         "wd:id":"Q2167734",
         "wk:page":"San Sebasti\u00e1n, Comayagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009565,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d72974b71e5e582c70efc95f7b0258f5",
+    "wof:geomhash":"0a710201f646291de7dd7dacb47c0f74",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421188523,
-    "wof:lastmodified":1690930271,
+    "wof:lastmodified":1695886635,
     "wof:name":"San Sebastian",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/188/527/421188527.geojson
+++ b/data/421/188/527/421188527.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018463,
-    "geom:area_square_m":220995849.828539,
+    "geom:area_square_m":220996117.027523,
     "geom:bbox":"-87.468727,14.444645,-87.295097,14.624174",
     "geom:latitude":14.524877,
     "geom:longitude":-87.381833,
@@ -115,12 +115,13 @@
         "wd:id":"Q1645152",
         "wk:page":"Vallecillo, Honduras"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009565,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fd0de2e499c0c5ed093d108817cfc766",
+    "wof:geomhash":"2ace8ac3c7745dafcd082470fea321de",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421188527,
-    "wof:lastmodified":1690930264,
+    "wof:lastmodified":1695886623,
     "wof:name":"Vallecillo",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/188/529/421188529.geojson
+++ b/data/421/188/529/421188529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115787,
-    "geom:area_square_m":1388797852.956394,
+    "geom:area_square_m":1388797406.491108,
     "geom:bbox":"-86.151649,13.832712,-85.569672,14.271607",
     "geom:latitude":14.065294,
     "geom:longitude":-85.858781,
@@ -121,12 +121,13 @@
         "wd:id":"Q2393154",
         "wk:page":"Trojes"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009565,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b5c7ac23ecd476d185289e2a4709b265",
+    "wof:geomhash":"c1ec28dd7e567b5332fd8b474be09e00",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421188529,
-    "wof:lastmodified":1690930265,
+    "wof:lastmodified":1695886624,
     "wof:name":"Trojes",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/188/531/421188531.geojson
+++ b/data/421/188/531/421188531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002835,
-    "geom:area_square_m":33875785.926821,
+    "geom:area_square_m":33875972.618411,
     "geom:bbox":"-88.836449,14.852359,-88.74926,14.927884",
     "geom:latitude":14.887385,
     "geom:longitude":-88.78803,
@@ -124,12 +124,13 @@
         "wd:id":"Q2344760",
         "wk:page":"Veracruz, Cop\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009568,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"594f06739ceae44b14af39e7a838795a",
+    "wof:geomhash":"afafec619c08e1bbb39a818d445d683c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421188531,
-    "wof:lastmodified":1690930267,
+    "wof:lastmodified":1695886626,
     "wof:name":"Veracruz",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/188/533/421188533.geojson
+++ b/data/421/188/533/421188533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02779,
-    "geom:area_square_m":333484969.791605,
+    "geom:area_square_m":333484795.880391,
     "geom:bbox":"-86.939667,13.864327,-86.708687,14.071579",
     "geom:latitude":13.955981,
     "geom:longitude":-86.826112,
@@ -222,12 +222,13 @@
         "wd:id":"Q1729098",
         "wk:page":"Yuscar\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009568,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4fac9ec3aa3b48112aea6a0314aea572",
+    "wof:geomhash":"a7388e8c15f6f951a1d898fafa662849",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -237,7 +238,7 @@
         }
     ],
     "wof:id":421188533,
-    "wof:lastmodified":1690930261,
+    "wof:lastmodified":1695886617,
     "wof:name":"Yuscaran",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/188/755/421188755.geojson
+++ b/data/421/188/755/421188755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044997,
-    "geom:area_square_m":536377441.248851,
+    "geom:area_square_m":536377245.845269,
     "geom:bbox":"-87.93866,15.224049,-87.685493,15.725393",
     "geom:latitude":15.4178,
     "geom:longitude":-87.804399,
@@ -186,12 +186,13 @@
         "wd:id":"Q2277161",
         "wk:page":"El Progreso"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009577,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4e6532bc5b5c3ecbea09af577df4df7b",
+    "wof:geomhash":"2e76303ca2c2e7d67b4bd064874f8ef2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -201,7 +202,7 @@
         }
     ],
     "wof:id":421188755,
-    "wof:lastmodified":1690930260,
+    "wof:lastmodified":1695886674,
     "wof:name":"El Progreso",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/188/757/421188757.geojson
+++ b/data/421/188/757/421188757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035365,
-    "geom:area_square_m":423165418.082449,
+    "geom:area_square_m":423165418.082417,
     "geom:bbox":"-88.7774581909,14.5109586716,-88.4949951172,14.7481861115",
     "geom:latitude":14.606193,
     "geom:longitude":-88.618722,
@@ -136,12 +136,13 @@
         "hasc:id":"HN.LE.GR",
         "qs_pg:id":1103786
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009577,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"47eafcf3356e25af5646e62d785c6d1b",
+    "wof:geomhash":"79da757bd24c53a6a09e154201e1fabc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":421188757,
-    "wof:lastmodified":1582319300,
+    "wof:lastmodified":1695886627,
     "wof:name":"Gracias",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/188/763/421188763.geojson
+++ b/data/421/188/763/421188763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028093,
-    "geom:area_square_m":334314521.055688,
+    "geom:area_square_m":334314998.724733,
     "geom:bbox":"-86.458771,15.661224,-86.162399,15.877424",
     "geom:latitude":15.760714,
     "geom:longitude":-86.302052,
@@ -127,12 +127,13 @@
         "wd:id":"Q2358773",
         "wk:page":"Balfate"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009578,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8ce5e6048319500046b645956a743d74",
+    "wof:geomhash":"b168f04aa8ea49e7fd6c6577ca325737",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421188763,
-    "wof:lastmodified":1690930260,
+    "wof:lastmodified":1695886616,
     "wof:name":"Balfate",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/188/765/421188765.geojson
+++ b/data/421/188/765/421188765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004829,
-    "geom:area_square_m":57257813.091892,
+    "geom:area_square_m":57257845.027743,
     "geom:bbox":"-85.951607,16.402555,-85.816002,16.516794",
     "geom:latitude":16.468545,
     "geom:longitude":-85.884145,
@@ -140,12 +140,13 @@
         "qs_pg:id":1103797,
         "wd:id":"Q1552720"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009578,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8924bcf2462600f97d46788668d83331",
+    "wof:geomhash":"4bbef087ebfe2539e5c7ecbaeb72cf14",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421188765,
-    "wof:lastmodified":1690930261,
+    "wof:lastmodified":1695886618,
     "wof:name":"Guanaja",
     "wof:parent_id":85671869,
     "wof:placetype":"county",

--- a/data/421/188/767/421188767.geojson
+++ b/data/421/188/767/421188767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044913,
-    "geom:area_square_m":534675605.009248,
+    "geom:area_square_m":534675475.627015,
     "geom:bbox":"-86.637062,15.573764,-86.362015,15.81664",
     "geom:latitude":15.685685,
     "geom:longitude":-86.504242,
@@ -145,12 +145,13 @@
         "wd:id":"Q775897",
         "wk:page":"Jutiapa, Atl\u00e1ntida"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009578,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"db95920d3ca643d2a9278e9d401aa4b8",
+    "wof:geomhash":"6f147a394316ba7f128f6f695f1f6bd3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -160,7 +161,7 @@
         }
     ],
     "wof:id":421188767,
-    "wof:lastmodified":1690930266,
+    "wof:lastmodified":1695886676,
     "wof:name":"Jutiapa",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/188/769/421188769.geojson
+++ b/data/421/188/769/421188769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089479,
-    "geom:area_square_m":1076922859.178961,
+    "geom:area_square_m":1076922833.032055,
     "geom:bbox":"-87.375191,12.987211,-87.039299,13.522587",
     "geom:latitude":13.260867,
     "geom:longitude":-87.231742,
@@ -116,12 +116,13 @@
         "hasc:id":"HN.CH.CH",
         "qs_pg:id":1103805
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009578,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f828041e51494fbfe1de05cbca49031f",
+    "wof:geomhash":"1cafa19c72c8a7868bda7c0b2472f32d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421188769,
-    "wof:lastmodified":1636495853,
+    "wof:lastmodified":1695886676,
     "wof:name":"Choluteca",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/188/771/421188771.geojson
+++ b/data/421/188/771/421188771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012352,
-    "geom:area_square_m":147621450.796128,
+    "geom:area_square_m":147621450.796106,
     "geom:bbox":"-88.1273269653,14.8135128021,-87.9811096191,14.9342889786",
     "geom:latitude":14.870619,
     "geom:longitude":-88.053521,
@@ -479,12 +479,13 @@
         "hasc:id":"HN.SB.LV",
         "qs_pg:id":1103807
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009578,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e8702804b38c116a1a2c7fe6767a4ddc",
+    "wof:geomhash":"ffb48fdf803cda9635b0a7973abf2275",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -494,7 +495,7 @@
         }
     ],
     "wof:id":421188771,
-    "wof:lastmodified":1582319293,
+    "wof:lastmodified":1695886624,
     "wof:name":"Las Vegas",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/188/773/421188773.geojson
+++ b/data/421/188/773/421188773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001888,
-    "geom:area_square_m":22619300.684606,
+    "geom:area_square_m":22619188.270287,
     "geom:bbox":"-87.74189,14.346504,-87.648605,14.390213",
     "geom:latitude":14.369412,
     "geom:longitude":-87.693118,
@@ -120,12 +120,13 @@
         "qs_pg:id":1103808,
         "wd:id":"Q2148930"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009578,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"da61217dc1eaf4bcd3c9a21575be9f80",
+    "wof:geomhash":"82a377d4745b8a1dd20caf37c15b6122",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421188773,
-    "wof:lastmodified":1690930270,
+    "wof:lastmodified":1695886635,
     "wof:name":"Lejamani",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/188/775/421188775.geojson
+++ b/data/421/188/775/421188775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040689,
-    "geom:area_square_m":489716674.97366,
+    "geom:area_square_m":489716816.57223,
     "geom:bbox":"-87.516449,13.099236,-87.257278,13.400434",
     "geom:latitude":13.256587,
     "geom:longitude":-87.376378,
@@ -117,12 +117,13 @@
         "qs_pg:id":1103809,
         "wd:id":"Q547593"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009578,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"232532ef70b56e9bc55bc8b6ac0bc589",
+    "wof:geomhash":"f49a5d79447de493060bb3cb3f05a247",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421188775,
-    "wof:lastmodified":1690930268,
+    "wof:lastmodified":1695886629,
     "wof:name":"Marcovia",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/188/779/421188779.geojson
+++ b/data/421/188/779/421188779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01947,
-    "geom:area_square_m":233278746.163855,
+    "geom:area_square_m":233278978.386438,
     "geom:bbox":"-87.869873,14.229015,-87.625908,14.39231",
     "geom:latitude":14.310068,
     "geom:longitude":-87.754247,
@@ -485,12 +485,13 @@
         "hasc:id":"HN.LP.LP",
         "qs_pg:id":1103810
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009578,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fc1d370b55bc5a410c223e3b06b1a0a1",
+    "wof:geomhash":"f727fda9c20272cb805d478ff56697fa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -500,7 +501,7 @@
         }
     ],
     "wof:id":421188779,
-    "wof:lastmodified":1636495852,
+    "wof:lastmodified":1695886675,
     "wof:name":"La Paz",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/188/781/421188781.geojson
+++ b/data/421/188/781/421188781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032922,
-    "geom:area_square_m":393862399.613863,
+    "geom:area_square_m":393862091.048159,
     "geom:bbox":"-88.021942,14.4979,-87.776886,14.809291",
     "geom:latitude":14.642702,
     "geom:longitude":-87.876678,
@@ -204,12 +204,13 @@
         "wd:id":"Q2552676",
         "wk:page":"Siguatepeque"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009578,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ab5570768f63f7969b6a1caf53eff98b",
+    "wof:geomhash":"cdae166a73bcfabc5035f30eed9ab160",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -219,7 +220,7 @@
         }
     ],
     "wof:id":421188781,
-    "wof:lastmodified":1690930270,
+    "wof:lastmodified":1695886634,
     "wof:name":"Siguatepeque",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/188/783/421188783.geojson
+++ b/data/421/188/783/421188783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080615,
-    "geom:area_square_m":959009431.851599,
+    "geom:area_square_m":959009121.169823,
     "geom:bbox":"-86.208527,15.629869,-85.698807,16.028637",
     "geom:latitude":15.830485,
     "geom:longitude":-85.939829,
@@ -212,12 +212,13 @@
         "hasc:id":"HN.CL.TR",
         "qs_pg:id":1103812
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009578,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2be2663b932cade139b805d704b0b6cb",
+    "wof:geomhash":"b8349efc82d86ba3d4f8a82ee2313cbc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -227,7 +228,7 @@
         }
     ],
     "wof:id":421188783,
-    "wof:lastmodified":1636495852,
+    "wof:lastmodified":1695886675,
     "wof:name":"Trujillo",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/190/809/421190809.geojson
+++ b/data/421/190/809/421190809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012962,
-    "geom:area_square_m":154753744.47854,
+    "geom:area_square_m":154753753.697372,
     "geom:bbox":"-88.680695,15.001077,-88.546516,15.166502",
     "geom:latitude":15.078057,
     "geom:longitude":-88.617767,
@@ -117,12 +117,13 @@
         "qs_pg:id":892472,
         "wd:id":"Q2362030"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009669,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e186475ce2df9f600b10caccc06d9b30",
+    "wof:geomhash":"f57f67a88f8d335d3f5f16d8a4384d90",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421190809,
-    "wof:lastmodified":1690930296,
+    "wof:lastmodified":1695886659,
     "wof:name":"Proteccion",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/191/079/421191079.geojson
+++ b/data/421/191/079/421191079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005171,
-    "geom:area_square_m":61937366.750326,
+    "geom:area_square_m":61937329.812484,
     "geom:bbox":"-87.789078,14.363906,-87.650612,14.432564",
     "geom:latitude":14.396828,
     "geom:longitude":-87.722317,
@@ -120,12 +120,13 @@
         "qs_pg:id":1130168,
         "wd:id":"Q762654"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009679,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9096f9e96e15747a4facebeeb84bda32",
+    "wof:geomhash":"483342ae40d1b6a04abf33d02a31362c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421191079,
-    "wof:lastmodified":1690930286,
+    "wof:lastmodified":1695886648,
     "wof:name":"Ajuterique",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/191/083/421191083.geojson
+++ b/data/421/191/083/421191083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016523,
-    "geom:area_square_m":198384870.004074,
+    "geom:area_square_m":198385091.377367,
     "geom:bbox":"-86.772438,13.768334,-86.574722,13.940014",
     "geom:latitude":13.835073,
     "geom:longitude":-86.688252,
@@ -120,12 +120,13 @@
         "qs_pg:id":1130169,
         "wd:id":"Q2391972"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009679,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1852e20ddb7b3847680d201f153d8b17",
+    "wof:geomhash":"9630a0d67d315af8827cbca29faeaa63",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421191083,
-    "wof:lastmodified":1690930286,
+    "wof:lastmodified":1695886649,
     "wof:name":"Alauca",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/191/085/421191085.geojson
+++ b/data/421/191/085/421191085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01718,
-    "geom:area_square_m":206616558.001111,
+    "geom:area_square_m":206616437.533353,
     "geom:bbox":"-87.820702,13.353303,-87.635254,13.542204",
     "geom:latitude":13.444602,
     "geom:longitude":-87.713129,
@@ -101,12 +101,13 @@
         "hasc:id":"HN.VA.AL",
         "qs_pg:id":1130170
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009679,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8ce8c9a5d706ae5b71f735788a8b4f4b",
+    "wof:geomhash":"be389bddffb1a4ba323fa63c8e7088e3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":421191085,
-    "wof:lastmodified":1627522171,
+    "wof:lastmodified":1695886637,
     "wof:name":"Alianza",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/191/087/421191087.geojson
+++ b/data/421/191/087/421191087.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042895,
-    "geom:area_square_m":511516117.741682,
+    "geom:area_square_m":511516117.742093,
     "geom:bbox":"-87.6534118652,15.1752910614,-87.4315414429,15.5214118958",
     "geom:latitude":15.336348,
     "geom:longitude":-87.561267,
@@ -113,12 +113,13 @@
         "hasc:id":"HN.YO.MO",
         "qs_pg:id":1130171
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009679,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"78028cf777014b0a172fe2274d178f60",
+    "wof:geomhash":"81746845eeb5adaedb397efec8480d2b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421191087,
-    "wof:lastmodified":1582319340,
+    "wof:lastmodified":1695886655,
     "wof:name":"Morazan",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/191/089/421191089.geojson
+++ b/data/421/191/089/421191089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051905,
-    "geom:area_square_m":617589227.986522,
+    "geom:area_square_m":617587680.813552,
     "geom:bbox":"-85.678986,15.672048,-85.283417,15.906867",
     "geom:latitude":15.795989,
     "geom:longitude":-85.514096,
@@ -124,12 +124,13 @@
         "wd:id":"Q1643266",
         "wk:page":"Lim\u00f3n, Honduras"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009679,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1cb811a228c831ce94dcd9e4648d1e2d",
+    "wof:geomhash":"2cfef99b5a0b593b0d58917c3d6eb450",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421191089,
-    "wof:lastmodified":1690930292,
+    "wof:lastmodified":1695886654,
     "wof:name":"Limon",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/421/191/091/421191091.geojson
+++ b/data/421/191/091/421191091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066567,
-    "geom:area_square_m":794741485.18065,
+    "geom:area_square_m":794741187.713641,
     "geom:bbox":"-87.768738,14.904819,-87.347862,15.285527",
     "geom:latitude":15.085713,
     "geom:longitude":-87.567261,
@@ -295,12 +295,13 @@
         "hasc:id":"HN.YO.VI",
         "qs_pg:id":1130177
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009679,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a2aa4cdc63ed7dd67a530c1d1800612b",
+    "wof:geomhash":"bb9941c18354046ad48e80117aa6a45e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -310,7 +311,7 @@
         }
     ],
     "wof:id":421191091,
-    "wof:lastmodified":1636495862,
+    "wof:lastmodified":1695886689,
     "wof:name":"Victoria",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/191/093/421191093.geojson
+++ b/data/421/191/093/421191093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006556,
-    "geom:area_square_m":78601274.925175,
+    "geom:area_square_m":78601382.3361,
     "geom:bbox":"-88.757988,14.101776,-88.65889,14.207615",
     "geom:latitude":14.153128,
     "geom:longitude":-88.711814,
@@ -121,12 +121,13 @@
         "wd:id":"Q1645823",
         "wk:page":"Valladolid, Lempira"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009679,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"34f4978e7717529c8480673f099149e3",
+    "wof:geomhash":"1052366c8390c689ee5497d657189150",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421191093,
-    "wof:lastmodified":1690930294,
+    "wof:lastmodified":1695886691,
     "wof:name":"Valladolid",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/191/339/421191339.geojson
+++ b/data/421/191/339/421191339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010741,
-    "geom:area_square_m":128423430.050995,
+    "geom:area_square_m":128423466.439093,
     "geom:bbox":"-89.130898,14.714473,-89.009621,14.853175",
     "geom:latitude":14.776721,
     "geom:longitude":-89.071832,
@@ -124,12 +124,13 @@
         "wd:id":"Q2393572",
         "wk:page":"Caba\u00f1as, La Paz"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ba362367e6df8ce0da28275aac463b9",
+    "wof:geomhash":"b18c4e3071fc52a6a80bb21df31d7f1f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421191339,
-    "wof:lastmodified":1690930285,
+    "wof:lastmodified":1695886647,
     "wof:name":"Cabanas",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/191/341/421191341.geojson
+++ b/data/421/191/341/421191341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005557,
-    "geom:area_square_m":66678619.367893,
+    "geom:area_square_m":66678401.914234,
     "geom:bbox":"-88.440979,13.955911,-88.331696,14.045259",
     "geom:latitude":13.996979,
     "geom:longitude":-88.388851,
@@ -114,12 +114,13 @@
         "qs_pg:id":62623,
         "wd:id":"Q2393269"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"79021d95f0024c7510f22219182332dc",
+    "wof:geomhash":"e5ec42ad2517ab54fee1b07cd0417af3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421191341,
-    "wof:lastmodified":1690930288,
+    "wof:lastmodified":1695886651,
     "wof:name":"Camasca",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/191/343/421191343.geojson
+++ b/data/421/191/343/421191343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005288,
-    "geom:area_square_m":63399088.802295,
+    "geom:area_square_m":63398700.435628,
     "geom:bbox":"-88.015266,14.132875,-87.880135,14.231846",
     "geom:latitude":14.185418,
     "geom:longitude":-87.958302,
@@ -120,12 +120,13 @@
         "qs_pg:id":62624,
         "wd:id":"Q2393377"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"471056c06b48972bba5506c51d387d7f",
+    "wof:geomhash":"91611ee8fb5be0f9e016034f622983a4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421191343,
-    "wof:lastmodified":1690930295,
+    "wof:lastmodified":1695886659,
     "wof:name":"Chinacla",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/191/345/421191345.geojson
+++ b/data/421/191/345/421191345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01136,
-    "geom:area_square_m":135555853.952457,
+    "geom:area_square_m":135555859.509321,
     "geom:bbox":"-88.205803,15.132394,-88.060402,15.267419",
     "geom:latitude":15.200606,
     "geom:longitude":-88.143777,
@@ -122,12 +122,13 @@
         "wd:id":"Q2340275",
         "wk:page":"Concepci\u00f3n del Sur"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e3d1f32de0def0a1765d647926b0904a",
+    "wof:geomhash":"438fc3b96fc847e348ef54dfa54641ad",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421191345,
-    "wof:lastmodified":1690930295,
+    "wof:lastmodified":1695886658,
     "wof:name":"Concepcion del Norte",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/191/347/421191347.geojson
+++ b/data/421/191/347/421191347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020534,
-    "geom:area_square_m":245659902.279622,
+    "geom:area_square_m":245659902.279393,
     "geom:bbox":"-86.8056335449,14.5735111237,-86.5995941162,14.7464427948",
     "geom:latitude":14.647605,
     "geom:longitude":-86.711059,
@@ -194,12 +194,13 @@
         "hasc:id":"HN.OL.CO",
         "qs_pg:id":62640
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2531e58df7d63044ef330a74ddf640a0",
+    "wof:geomhash":"87a0c5f402b49dacd86ba1dfcaa65355",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -209,7 +210,7 @@
         }
     ],
     "wof:id":421191347,
-    "wof:lastmodified":1582319337,
+    "wof:lastmodified":1695886651,
     "wof:name":"Concordia",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/349/421191349.geojson
+++ b/data/421/191/349/421191349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034747,
-    "geom:area_square_m":415398324.762731,
+    "geom:area_square_m":415398415.506752,
     "geom:bbox":"-86.936142,14.639317,-86.72364,14.939021",
     "geom:latitude":14.801392,
     "geom:longitude":-86.831443,
@@ -117,12 +117,13 @@
         "qs_pg:id":62660,
         "wd:id":"Q2394969"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8473aec9ce3c365bfce6c6f445641554",
+    "wof:geomhash":"9ee74829d570554c56c2e0098accc2da",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421191349,
-    "wof:lastmodified":1690930289,
+    "wof:lastmodified":1695886652,
     "wof:name":"Guayape",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/353/421191353.geojson
+++ b/data/421/191/353/421191353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004541,
-    "geom:area_square_m":54431306.662319,
+    "geom:area_square_m":54431336.162034,
     "geom:bbox":"-87.764359,14.179958,-87.64753,14.268916",
     "geom:latitude":14.224123,
     "geom:longitude":-87.707443,
@@ -117,12 +117,13 @@
         "qs_pg:id":62661,
         "wd:id":"Q1643258"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e9b2c3acb81c3f9ee59dff97cd808b03",
+    "wof:geomhash":"6a5c59c985425eca97c2fe729d54c7f8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421191353,
-    "wof:lastmodified":1690930284,
+    "wof:lastmodified":1695886646,
     "wof:name":"Humuya",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/191/355/421191355.geojson
+++ b/data/421/191/355/421191355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007167,
-    "geom:area_square_m":85713449.849965,
+    "geom:area_square_m":85713402.873641,
     "geom:bbox":"-87.753822,14.664433,-87.599678,14.740509",
     "geom:latitude":14.707614,
     "geom:longitude":-87.671333,
@@ -118,12 +118,13 @@
         "wd:id":"Q1643280",
         "wk:page":"La Trinidad, Comayagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b523824abeb34fafc4d2bf91d048c56",
+    "wof:geomhash":"76da2ca0c1ce2c1ad17dc42ce8cdfa48",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421191355,
-    "wof:lastmodified":1690930285,
+    "wof:lastmodified":1695886647,
     "wof:name":"La Trinidad",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/191/357/421191357.geojson
+++ b/data/421/191/357/421191357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012785,
-    "geom:area_square_m":152714159.727201,
+    "geom:area_square_m":152714221.876067,
     "geom:bbox":"-88.477859,14.92827,-88.258698,15.020857",
     "geom:latitude":14.97836,
     "geom:longitude":-88.374326,
@@ -117,12 +117,13 @@
         "qs_pg:id":62690,
         "wd:id":"Q1846407"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"93a42a4d48b85dfe5f3cecef582e50b8",
+    "wof:geomhash":"a59c4e8fda6e3fff07618d5fc40762ae",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421191357,
-    "wof:lastmodified":1690930291,
+    "wof:lastmodified":1695886653,
     "wof:name":"Nuevo Celilac",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/191/359/421191359.geojson
+++ b/data/421/191/359/421191359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014469,
-    "geom:area_square_m":172969225.431904,
+    "geom:area_square_m":172968987.652726,
     "geom:bbox":"-87.755959,14.727164,-87.554726,14.875298",
     "geom:latitude":14.805035,
     "geom:longitude":-87.653252,
@@ -103,12 +103,13 @@
         "qs_pg:id":62691,
         "wd:id":"Q3881323"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"23090029493242718dd87abf78d65c9d",
+    "wof:geomhash":"dca6bfa52b681b7fbd8d6cea98d1b581",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":421191359,
-    "wof:lastmodified":1627522180,
+    "wof:lastmodified":1695886655,
     "wof:name":"Ojos de Agua",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/191/361/421191361.geojson
+++ b/data/421/191/361/421191361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03352,
-    "geom:area_square_m":400737720.113907,
+    "geom:area_square_m":400738010.634838,
     "geom:bbox":"-87.03817,14.638245,-86.82856,15.001498",
     "geom:latitude":14.797833,
     "geom:longitude":-86.945402,
@@ -118,12 +118,13 @@
         "wd:id":"Q304913",
         "wk:page":"Orica, Francisco Moraz\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"32737fc1352a546f497903bea590d724",
+    "wof:geomhash":"95019595d76c77f9f8211268799c1114",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421191361,
-    "wof:lastmodified":1690930290,
+    "wof:lastmodified":1695886653,
     "wof:name":"Orica",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/191/363/421191363.geojson
+++ b/data/421/191/363/421191363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063569,
-    "geom:area_square_m":761638754.882203,
+    "geom:area_square_m":761639257.16959,
     "geom:bbox":"-86.150299,14.123881,-85.803917,14.528406",
     "geom:latitude":14.313746,
     "geom:longitude":-85.963011,
@@ -118,12 +118,13 @@
         "wd:id":"Q2394584",
         "wk:page":"Patuca"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dd96255802df753cad60dfc7cb7bfdbf",
+    "wof:geomhash":"fa97962ed40d2addc60789b6a890c054",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421191363,
-    "wof:lastmodified":1690930285,
+    "wof:lastmodified":1695886647,
     "wof:name":"Patuca",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/365/421191365.geojson
+++ b/data/421/191/365/421191365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003548,
-    "geom:area_square_m":42620139.267918,
+    "geom:area_square_m":42620210.217357,
     "geom:bbox":"-87.528389,13.708453,-87.450592,13.795041",
     "geom:latitude":13.749542,
     "geom:longitude":-87.491173,
@@ -121,12 +121,13 @@
         "wd:id":"Q532321",
         "wk:page":"San Miguelito, Francisco Moraz\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009689,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3f5b0613332487ef0568e1ecb79d565b",
+    "wof:geomhash":"303418e61a6c6a59a8db04fa1e880b00",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421191365,
-    "wof:lastmodified":1690930284,
+    "wof:lastmodified":1695886646,
     "wof:name":"San Miguelito",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/191/367/421191367.geojson
+++ b/data/421/191/367/421191367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00631,
-    "geom:area_square_m":75370861.950713,
+    "geom:area_square_m":75370593.512266,
     "geom:bbox":"-88.829826,14.96937,-88.6772,15.036601",
     "geom:latitude":14.999865,
     "geom:longitude":-88.74331,
@@ -121,12 +121,13 @@
         "wd:id":"Q1644014",
         "wk:page":"San Nicol\u00e1s, Cop\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"111dd8375cfc7d428d3e1c4c5789eb68",
+    "wof:geomhash":"a1ab7e4388fc5fc93e26bd7529480899",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421191367,
-    "wof:lastmodified":1690930291,
+    "wof:lastmodified":1695886655,
     "wof:name":"San Nicolas",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/191/373/421191373.geojson
+++ b/data/421/191/373/421191373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003154,
-    "geom:area_square_m":37686349.194422,
+    "geom:area_square_m":37686184.185177,
     "geom:bbox":"-88.331215,14.848716,-88.254143,14.921032",
     "geom:latitude":14.886178,
     "geom:longitude":-88.302581,
@@ -114,12 +114,13 @@
         "qs_pg:id":62722,
         "wd:id":"Q2179819"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9c826c350bac77c4125f1543475a70c2",
+    "wof:geomhash":"e29334b32f32a9a71f2b54197f8bf5f6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421191373,
-    "wof:lastmodified":1690930295,
+    "wof:lastmodified":1695886659,
     "wof:name":"San Vicente Centenario",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/191/375/421191375.geojson
+++ b/data/421/191/375/421191375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015407,
-    "geom:area_square_m":184792528.734417,
+    "geom:area_square_m":184792605.462005,
     "geom:bbox":"-88.236511,13.983842,-88.091309,14.155309",
     "geom:latitude":14.065938,
     "geom:longitude":-88.159647,
@@ -158,12 +158,13 @@
         "hasc:id":"HN.LP.SE",
         "qs_pg:id":62733
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"009e846ea88a41496d597ededadf9a2d",
+    "wof:geomhash":"bf310f6efb8ddb28be523f1439687e24",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":421191375,
-    "wof:lastmodified":1636495864,
+    "wof:lastmodified":1695886692,
     "wof:name":"Santa Elena",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/191/379/421191379.geojson
+++ b/data/421/191/379/421191379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008738,
-    "geom:area_square_m":104716487.407873,
+    "geom:area_square_m":104716572.72535,
     "geom:bbox":"-88.0065,14.188087,-87.848,14.327929",
     "geom:latitude":14.271608,
     "geom:longitude":-87.920932,
@@ -154,12 +154,13 @@
         "wd:id":"Q2394137",
         "wk:page":"Santa Mar\u00eda, La Paz"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"247103ece347e621b0ffa0557eb24fc8",
+    "wof:geomhash":"e1971c91305254da073785b9d0835d20",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":421191379,
-    "wof:lastmodified":1690930288,
+    "wof:lastmodified":1695886690,
     "wof:name":"Santa Maria",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/191/381/421191381.geojson
+++ b/data/421/191/381/421191381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026371,
-    "geom:area_square_m":315131879.06122,
+    "geom:area_square_m":315131931.369274,
     "geom:bbox":"-89.144905,14.773036,-88.939224,14.970896",
     "geom:latitude":14.886769,
     "geom:longitude":-89.036013,
@@ -169,12 +169,13 @@
         "wd:id":"Q2394334",
         "wk:page":"Santa Rita, Santa B\u00e1rbara"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fd29e705c95df20088777f22cc0d5057",
+    "wof:geomhash":"41c3e75fa34cca645557807624ca371a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -184,7 +185,7 @@
         }
     ],
     "wof:id":421191381,
-    "wof:lastmodified":1690930295,
+    "wof:lastmodified":1695886692,
     "wof:name":"Santa Rita",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/191/383/421191383.geojson
+++ b/data/421/191/383/421191383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02126,
-    "geom:area_square_m":254209994.702667,
+    "geom:area_square_m":254209830.806309,
     "geom:bbox":"-86.635399,14.681649,-86.424652,14.870281",
     "geom:latitude":14.762952,
     "geom:longitude":-86.527394,
@@ -118,12 +118,13 @@
         "wd:id":"Q2394989",
         "wk:page":"Silca"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8132d0c9f3f5f8aaddd700c5b6015c9e",
+    "wof:geomhash":"1044fc9ad8dba6f48905eed6d97c484e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421191383,
-    "wof:lastmodified":1690930289,
+    "wof:lastmodified":1695886651,
     "wof:name":"Silca",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/385/421191385.geojson
+++ b/data/421/191/385/421191385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013164,
-    "geom:area_square_m":158198702.424135,
+    "geom:area_square_m":158198834.523294,
     "geom:bbox":"-87.224709,13.547846,-87.053017,13.686021",
     "geom:latitude":13.614677,
     "geom:longitude":-87.147057,
@@ -156,12 +156,13 @@
         "wd:id":"Q2392467",
         "wk:page":"Soledad, El Para\u00edso"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8bc0666f08b563a63f2c5286150716f3",
+    "wof:geomhash":"689756b3f02f04f50006fd153fda1252",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":421191385,
-    "wof:lastmodified":1690930289,
+    "wof:lastmodified":1695886691,
     "wof:name":"Soledad",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/191/389/421191389.geojson
+++ b/data/421/191/389/421191389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007283,
-    "geom:area_square_m":87338956.079013,
+    "geom:area_square_m":87338905.135288,
     "geom:bbox":"-88.159225,13.996936,-88.029732,14.179682",
     "geom:latitude":14.108161,
     "geom:longitude":-88.092852,
@@ -138,12 +138,13 @@
         "qs_pg:id":62755,
         "wd:id":"Q2393556"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"006282076e383201727c875acde023b6",
+    "wof:geomhash":"ee62f6fe48880a2a7f2917fdbcd866d3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421191389,
-    "wof:lastmodified":1690930294,
+    "wof:lastmodified":1695886658,
     "wof:name":"Yarula",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/191/391/421191391.geojson
+++ b/data/421/191/391/421191391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00542,
-    "geom:area_square_m":65092483.234975,
+    "geom:area_square_m":65092660.879717,
     "geom:bbox":"-87.122314,13.704893,-87.029915,13.80815",
     "geom:latitude":13.751106,
     "geom:longitude":-87.079573,
@@ -123,12 +123,13 @@
         "qs_pg:id":62756,
         "wd:id":"Q2392519"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3e135fc2c6868ea73187cd751282fc53",
+    "wof:geomhash":"3e154625180d9029fbefc4282644350a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421191391,
-    "wof:lastmodified":1690930284,
+    "wof:lastmodified":1695886647,
     "wof:name":"Yauyupe",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/191/393/421191393.geojson
+++ b/data/421/191/393/421191393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020725,
-    "geom:area_square_m":247583238.768868,
+    "geom:area_square_m":247583647.32122,
     "geom:bbox":"-86.971115,14.893645,-86.695068,15.01875",
     "geom:latitude":14.959911,
     "geom:longitude":-86.811608,
@@ -120,12 +120,13 @@
         "qs_pg:id":62757,
         "wd:id":"Q2394940"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2af65aee5fb4a8238300f6cacd410deb",
+    "wof:geomhash":"86c507fed8cbf417e7a8b20bec8c314c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421191393,
-    "wof:lastmodified":1690930291,
+    "wof:lastmodified":1695886655,
     "wof:name":"Yocon",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/601/421191601.geojson
+++ b/data/421/191/601/421191601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016267,
-    "geom:area_square_m":195299501.953707,
+    "geom:area_square_m":195299753.368605,
     "geom:bbox":"-87.495583,13.748929,-87.366638,13.930883",
     "geom:latitude":13.851459,
     "geom:longitude":-87.429119,
@@ -120,12 +120,13 @@
         "qs_pg:id":62698,
         "wd:id":"Q2604760"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009698,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"11ad15fcbb1f48a80f31320e1b30401b",
+    "wof:geomhash":"f898aefea04fd853787ec08555907176",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421191601,
-    "wof:lastmodified":1690930294,
+    "wof:lastmodified":1695886658,
     "wof:name":"Reitoca",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/191/669/421191669.geojson
+++ b/data/421/191/669/421191669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031849,
-    "geom:area_square_m":381287603.942372,
+    "geom:area_square_m":381287672.915855,
     "geom:bbox":"-86.751411,14.373542,-86.544189,14.596931",
     "geom:latitude":14.492137,
     "geom:longitude":-86.641423,
@@ -192,12 +192,13 @@
         "qs_pg:id":1150580,
         "wd:id":"Q2394161"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009701,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2e8e64e30bc70fb877f2cf16fc7b2431",
+    "wof:geomhash":"ba1c5a0f4d65ffabb781b530f2fa5789",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -207,7 +208,7 @@
         }
     ],
     "wof:id":421191669,
-    "wof:lastmodified":1690930287,
+    "wof:lastmodified":1695886650,
     "wof:name":"Campamento",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/191/671/421191671.geojson
+++ b/data/421/191/671/421191671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033823,
-    "geom:area_square_m":404094888.698576,
+    "geom:area_square_m":404095087.128972,
     "geom:bbox":"-87.22319,14.845339,-86.988464,15.033292",
     "geom:latitude":14.937967,
     "geom:longitude":-87.102447,
@@ -118,12 +118,13 @@
         "wd:id":"Q2315619",
         "wk:page":"Marale"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009701,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a25f44329938af024432589bf5aba182",
+    "wof:geomhash":"aa36d07aceb5bd572b1a0f0877b4d64d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421191671,
-    "wof:lastmodified":1690930292,
+    "wof:lastmodified":1695886657,
     "wof:name":"Marale",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/191/673/421191673.geojson
+++ b/data/421/191/673/421191673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029855,
-    "geom:area_square_m":356078609.396033,
+    "geom:area_square_m":356078111.610477,
     "geom:bbox":"-87.099136,15.180607,-86.817818,15.396344",
     "geom:latitude":15.300004,
     "geom:longitude":-86.956904,
@@ -117,12 +117,13 @@
         "qs_pg:id":1150582,
         "wd:id":"Q2308179"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009701,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2f63784fc4ace50f5a23f03a34dfd0b8",
+    "wof:geomhash":"7465f4583e3d8f0b075179fb9bc2d5ad",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421191673,
-    "wof:lastmodified":1690930287,
+    "wof:lastmodified":1695886649,
     "wof:name":"Jocon",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/191/677/421191677.geojson
+++ b/data/421/191/677/421191677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027808,
-    "geom:area_square_m":332528762.127546,
+    "geom:area_square_m":332528130.014377,
     "geom:bbox":"-87.159294,14.603469,-86.973892,14.853873",
     "geom:latitude":14.743991,
     "geom:longitude":-87.055937,
@@ -127,12 +127,13 @@
         "wd:id":"Q925890",
         "wk:page":"San Ignacio, Francisco Moraz\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009701,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cdb4f06c5c30a352fabe2cec02ee9f30",
+    "wof:geomhash":"3f31a791d14bcdffdec4b20523ae49d7",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421191677,
-    "wof:lastmodified":1690930293,
+    "wof:lastmodified":1695886691,
     "wof:name":"San Ignacio",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/191/679/421191679.geojson
+++ b/data/421/191/679/421191679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006004,
-    "geom:area_square_m":72139670.622329,
+    "geom:area_square_m":72139432.902885,
     "geom:bbox":"-87.310455,13.606203,-87.211609,13.687677",
     "geom:latitude":13.646513,
     "geom:longitude":-87.260128,
@@ -115,12 +115,13 @@
         "wd:id":"Q585662",
         "wk:page":"San Isidro, Choluteca"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009701,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"638e85d7416524ca797046385afcc2ed",
+    "wof:geomhash":"b27e641536211b263ec8caa4b57bc92b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421191679,
-    "wof:lastmodified":1690930293,
+    "wof:lastmodified":1695886657,
     "wof:name":"San Isidro",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/191/683/421191683.geojson
+++ b/data/421/191/683/421191683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003991,
-    "geom:area_square_m":47834691.906254,
+    "geom:area_square_m":47834609.085714,
     "geom:bbox":"-88.792824,14.2229,-88.68364,14.288541",
     "geom:latitude":14.249925,
     "geom:longitude":-88.739872,
@@ -114,12 +114,13 @@
         "qs_pg:id":1150588,
         "wd:id":"Q1645799"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009701,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"770bd3c08fcaf261b5d4f22756d500c2",
+    "wof:geomhash":"5dcbeca566f93b097a4fd14ebdd34aca",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421191683,
-    "wof:lastmodified":1690930293,
+    "wof:lastmodified":1695886657,
     "wof:name":"Tomala",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/192/627/421192627.geojson
+++ b/data/421/192/627/421192627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029072,
-    "geom:area_square_m":347114934.380199,
+    "geom:area_square_m":347115069.890179,
     "geom:bbox":"-86.624016,14.917712,-86.408554,15.202773",
     "geom:latitude":15.072024,
     "geom:longitude":-86.518759,
@@ -123,12 +123,13 @@
         "qs_pg:id":1168617,
         "wd:id":"Q371054"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009743,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"88351cca0f48a62855fed5952d636275",
+    "wof:geomhash":"9facf39892e5639834f15b4068516e22",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":421192627,
-    "wof:lastmodified":1690930228,
+    "wof:lastmodified":1695886595,
     "wof:name":"Jano",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/193/293/421193293.geojson
+++ b/data/421/193/293/421193293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018875,
-    "geom:area_square_m":226148772.513469,
+    "geom:area_square_m":226148901.322368,
     "geom:bbox":"-88.981537,14.203059,-88.783218,14.411603",
     "geom:latitude":14.310689,
     "geom:longitude":-88.88451,
@@ -118,12 +118,13 @@
         "wd:id":"Q2234966",
         "wk:page":"Cololaca"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009766,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ea37ee35a3f9ec4e40f42ff95fa63cfe",
+    "wof:geomhash":"945ecf6b5c55e8fc4c25623f6d267c25",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421193293,
-    "wof:lastmodified":1690930235,
+    "wof:lastmodified":1695886599,
     "wof:name":"Cololaca",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/193/297/421193297.geojson
+++ b/data/421/193/297/421193297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005477,
-    "geom:area_square_m":65376922.273547,
+    "geom:area_square_m":65376797.183172,
     "geom:bbox":"-88.223183,15.093946,-88.100365,15.227943",
     "geom:latitude":15.135236,
     "geom:longitude":-88.163453,
@@ -118,12 +118,13 @@
         "qs_pg:id":884751,
         "wd:id":"Q2219807"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009766,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9277c6b54791972a969d4e26d66cc51e",
+    "wof:geomhash":"840b3ef53b5b480b4f9840047b631dcf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421193297,
-    "wof:lastmodified":1690930238,
+    "wof:lastmodified":1695886602,
     "wof:name":"Chinda",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/193/299/421193299.geojson
+++ b/data/421/193/299/421193299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005211,
-    "geom:area_square_m":62551497.498241,
+    "geom:area_square_m":62551527.812191,
     "geom:bbox":"-87.220329,13.84271,-87.148155,13.965471",
     "geom:latitude":13.898621,
     "geom:longitude":-87.183919,
@@ -118,12 +118,13 @@
         "wd:id":"Q2393112",
         "wk:page":"San Buenaventura, Francisco Moraz\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009766,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a94cbbf5b58af55299ac8d24fabd9556",
+    "wof:geomhash":"be7aa7762e778df93066b5adaabf171a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421193299,
-    "wof:lastmodified":1690930239,
+    "wof:lastmodified":1695886602,
     "wof:name":"San Buenaventura",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/193/573/421193573.geojson
+++ b/data/421/193/573/421193573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.196413,
-    "geom:area_square_m":2341954910.55598,
+    "geom:area_square_m":2341955245.350165,
     "geom:bbox":"-84.582451,15.002788,-84.113487,15.8109",
     "geom:latitude":15.357389,
     "geom:longitude":-84.353184,
@@ -130,12 +130,13 @@
         "wd:id":"Q2393126",
         "wk:page":"Ahuas"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009775,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7c37e4dc13e3d0e642bb7a6b39e09a26",
+    "wof:geomhash":"be1c08690198b5b8237395bc7e6b54ee",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":421193573,
-    "wof:lastmodified":1690930236,
+    "wof:lastmodified":1695886600,
     "wof:name":"Ahuas",
     "wof:parent_id":85671867,
     "wof:placetype":"county",

--- a/data/421/193/683/421193683.geojson
+++ b/data/421/193/683/421193683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003869,
-    "geom:area_square_m":46464519.298923,
+    "geom:area_square_m":46464494.041147,
     "geom:bbox":"-87.525162,13.753516,-87.413101,13.821182",
     "geom:latitude":13.786312,
     "geom:longitude":-87.470747,
@@ -126,12 +126,13 @@
         "qs_pg:id":62619,
         "wd:id":"Q676725"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009779,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e2fd924aa7276c1f870d61bbea31036e",
+    "wof:geomhash":"ae076b454f4ee117539311925e812488",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421193683,
-    "wof:lastmodified":1690930237,
+    "wof:lastmodified":1695886602,
     "wof:name":"Alubaren",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/193/685/421193685.geojson
+++ b/data/421/193/685/421193685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019089,
-    "geom:area_square_m":229557912.905248,
+    "geom:area_square_m":229558068.276715,
     "geom:bbox":"-87.121887,13.379583,-86.92025,13.540045",
     "geom:latitude":13.455259,
     "geom:longitude":-87.015696,
@@ -118,12 +118,13 @@
         "wd:id":"Q2360971",
         "wk:page":"Apacilagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009779,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1d9515dd6a8572947e53e94e8f80d054",
+    "wof:geomhash":"12809c957d93d4e5d258dd823f3f3900",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421193685,
-    "wof:lastmodified":1690930237,
+    "wof:lastmodified":1695886602,
     "wof:name":"Apacilagua",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/193/687/421193687.geojson
+++ b/data/421/193/687/421193687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021191,
-    "geom:area_square_m":253813632.79678,
+    "geom:area_square_m":253813670.361593,
     "geom:bbox":"-88.06926,14.27217,-87.847618,14.4979",
     "geom:latitude":14.388843,
     "geom:longitude":-87.970895,
@@ -118,12 +118,13 @@
         "wd:id":"Q948576",
         "wk:page":"Masaguara"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009779,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7aec81056afea91f15750ff3a25e4544",
+    "wof:geomhash":"06a8aa0a46db6b0b6088ad0ed86e27b6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421193687,
-    "wof:lastmodified":1690930235,
+    "wof:lastmodified":1695886599,
     "wof:name":"Masaguara",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/193/689/421193689.geojson
+++ b/data/421/193/689/421193689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003307,
-    "geom:area_square_m":39695929.852726,
+    "geom:area_square_m":39695915.783621,
     "geom:bbox":"-87.807602,13.866605,-87.75029,13.986382",
     "geom:latitude":13.918788,
     "geom:longitude":-87.779741,
@@ -109,12 +109,13 @@
         "qs_pg:id":62689,
         "wd:id":"Q2394007"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009780,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"89845dae66678e8b2a209bfc77eca52c",
+    "wof:geomhash":"5c5deb11f0c4ba9098d25c13ca67c876",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":421193689,
-    "wof:lastmodified":1627522179,
+    "wof:lastmodified":1695886653,
     "wof:name":"Mercedes de Oriente",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/193/695/421193695.geojson
+++ b/data/421/193/695/421193695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009973,
-    "geom:area_square_m":119091305.704801,
+    "geom:area_square_m":119091434.482038,
     "geom:bbox":"-88.929482,14.979927,-88.82843,15.141335",
     "geom:latitude":15.052509,
     "geom:longitude":-88.88808,
@@ -124,12 +124,13 @@
         "wd:id":"Q2314026",
         "wk:page":"San Antonio, Cop\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009780,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c5c9f37a7c0877aed563fb9cfdaa06a4",
+    "wof:geomhash":"861928aad560fb1f54e287952230334c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421193695,
-    "wof:lastmodified":1690930236,
+    "wof:lastmodified":1695886670,
     "wof:name":"San Antonio",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/193/697/421193697.geojson
+++ b/data/421/193/697/421193697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024475,
-    "geom:area_square_m":292847185.135629,
+    "geom:area_square_m":292847470.910311,
     "geom:bbox":"-86.146561,14.507222,-85.959602,14.735022",
     "geom:latitude":14.613891,
     "geom:longitude":-86.043198,
@@ -91,12 +91,13 @@
         "qs_pg:id":62708,
         "wd:id":"Q2394598"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009780,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"299ebd2e37da60d38b55f698199413e2",
+    "wof:geomhash":"023b86257717659fad378d2f940b9dd3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421193697,
-    "wof:lastmodified":1627522181,
+    "wof:lastmodified":1695886657,
     "wof:name":"San Francisco de Becerra",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/193/699/421193699.geojson
+++ b/data/421/193/699/421193699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015025,
-    "geom:area_square_m":179705415.164889,
+    "geom:area_square_m":179705687.559946,
     "geom:bbox":"-88.347885,14.643879,-88.151031,14.788236",
     "geom:latitude":14.700423,
     "geom:longitude":-88.229683,
@@ -91,12 +91,13 @@
         "qs_pg:id":62709,
         "wd:id":"Q2395039"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009780,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f891c6ac16046ddfe4d310310a51c3ee",
+    "wof:geomhash":"a8aadf62a7b1d4b1a876d75235fb1c9d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421193699,
-    "wof:lastmodified":1627522182,
+    "wof:lastmodified":1695886658,
     "wof:name":"San Francisco de Ojuera",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/193/701/421193701.geojson
+++ b/data/421/193/701/421193701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00495,
-    "geom:area_square_m":59222076.548495,
+    "geom:area_square_m":59222049.312356,
     "geom:bbox":"-89.157738,14.584917,-89.008156,14.726563",
     "geom:latitude":14.652949,
     "geom:longitude":-89.101513,
@@ -119,12 +119,13 @@
         "wd:id":"Q1896807",
         "wk:page":"San Jorge, Ocotepeque"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009780,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"13d8dc81461d1cd8db159667f8151e18",
+    "wof:geomhash":"c59231df9c4ddeb32c4d2310f74ca575",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421193701,
-    "wof:lastmodified":1690930234,
+    "wof:lastmodified":1695886598,
     "wof:name":"San Jorge",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/194/673/421194673.geojson
+++ b/data/421/194/673/421194673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008368,
-    "geom:area_square_m":99847365.49758,
+    "geom:area_square_m":99847424.862509,
     "geom:bbox":"-88.022331,15.11318,-87.904549,15.253902",
     "geom:latitude":15.197686,
     "geom:longitude":-87.960086,
@@ -121,12 +121,13 @@
         "wd:id":"Q1644959",
         "wk:page":"Potrerillos, Cort\u00e9s"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009815,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a0a7675568ae147090a8f91dc8f66934",
+    "wof:geomhash":"e837edcdd433ef8769b7e397d2064069",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421194673,
-    "wof:lastmodified":1690930231,
+    "wof:lastmodified":1695886597,
     "wof:name":"Potrerillos",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/194/943/421194943.geojson
+++ b/data/421/194/943/421194943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011623,
-    "geom:area_square_m":139106746.829715,
+    "geom:area_square_m":139106951.5601,
     "geom:bbox":"-88.930244,14.496684,-88.733536,14.611496",
     "geom:latitude":14.56341,
     "geom:longitude":-88.849007,
@@ -120,12 +120,13 @@
         "qs_pg:id":62641,
         "wd:id":"Q1119909"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009825,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"76d6b8e8de2db3325062f7febf1f8316",
+    "wof:geomhash":"f40c56845ddbcb6dbaa3f8b15b115031",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421194943,
-    "wof:lastmodified":1690930233,
+    "wof:lastmodified":1695886597,
     "wof:name":"Corquin",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/194/945/421194945.geojson
+++ b/data/421/194/945/421194945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025737,
-    "geom:area_square_m":309024659.245117,
+    "geom:area_square_m":309024807.45893,
     "geom:bbox":"-87.650055,13.713131,-87.480751,13.955777",
     "geom:latitude":13.827842,
     "geom:longitude":-87.568722,
@@ -120,12 +120,13 @@
         "qs_pg:id":62642,
         "wd:id":"Q2392548"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009825,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c177ee6443689aa15affb31a5c1a71ff",
+    "wof:geomhash":"864594850a846207f44362a539941783",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421194945,
-    "wof:lastmodified":1690930233,
+    "wof:lastmodified":1695886598,
     "wof:name":"Curaren",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/194/947/421194947.geojson
+++ b/data/421/194/947/421194947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00949,
-    "geom:area_square_m":113285915.635291,
+    "geom:area_square_m":113286097.819558,
     "geom:bbox":"-88.82843,15.017965,-88.703384,15.196815",
     "geom:latitude":15.11035,
     "geom:longitude":-88.764398,
@@ -88,12 +88,13 @@
         "hasc:id":"HN.CP.LJ",
         "qs_pg:id":62662
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009825,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c4164b7377124525bc992eaec0954da2",
+    "wof:geomhash":"83519ff5982fcc4a7fe81190fd305dae",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421194947,
-    "wof:lastmodified":1627522179,
+    "wof:lastmodified":1695886653,
     "wof:name":"La Jigua",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/194/949/421194949.geojson
+++ b/data/421/194/949/421194949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00325,
-    "geom:area_square_m":39044951.688594,
+    "geom:area_square_m":39044850.328606,
     "geom:bbox":"-87.549164,13.669556,-87.458626,13.743116",
     "geom:latitude":13.707326,
     "geom:longitude":-87.500541,
@@ -125,12 +125,13 @@
         "wd:id":"Q1644896",
         "wk:page":"La Libertad, Francisco Moraz\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009825,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a598f34d85710c2cb2c3cc410f38d5d1",
+    "wof:geomhash":"86b002eb147a0752a55f3c8a34bed4d9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421194949,
-    "wof:lastmodified":1690930231,
+    "wof:lastmodified":1695886670,
     "wof:name":"La Libertad",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/194/955/421194955.geojson
+++ b/data/421/194/955/421194955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007992,
-    "geom:area_square_m":95501675.332718,
+    "geom:area_square_m":95501909.305624,
     "geom:bbox":"-87.707932,14.857934,-87.557106,14.941174",
     "geom:latitude":14.894441,
     "geom:longitude":-87.632854,
@@ -154,12 +154,13 @@
         "wd:id":"Q2360984",
         "wk:page":"Las Lajas, Honduras"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009825,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b88303c5281504489db4655db6c3dc75",
+    "wof:geomhash":"2a6b7603da02885728ede922cd06103b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -169,7 +170,7 @@
         }
     ],
     "wof:id":421194955,
-    "wof:lastmodified":1690930230,
+    "wof:lastmodified":1695886670,
     "wof:name":"Las Lajas",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/194/957/421194957.geojson
+++ b/data/421/194/957/421194957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003068,
-    "geom:area_square_m":36830653.786299,
+    "geom:area_square_m":36830622.861843,
     "geom:bbox":"-87.693321,13.830267,-87.614754,13.893181",
     "geom:latitude":13.862735,
     "geom:longitude":-87.655135,
@@ -132,12 +132,13 @@
         "qs_pg:id":62672,
         "wd:id":"Q2132428"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009825,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8366b3c6afc9412ae4a9ba98510aef88",
+    "wof:geomhash":"36fce95fcc017b4287bc20e69d011058",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421194957,
-    "wof:lastmodified":1690930232,
+    "wof:lastmodified":1695886598,
     "wof:name":"Lauterique",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/194/961/421194961.geojson
+++ b/data/421/194/961/421194961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004665,
-    "geom:area_square_m":55647159.677355,
+    "geom:area_square_m":55646982.443297,
     "geom:bbox":"-88.020012,15.236257,-87.910942,15.307597",
     "geom:latitude":15.274626,
     "geom:longitude":-87.970193,
@@ -118,12 +118,13 @@
         "wd:id":"Q1644985",
         "wk:page":"Pimienta, Honduras"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009826,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"15cf76f4e3c419bf0189c4067774414e",
+    "wof:geomhash":"52b8484f2080ebba5e9594c9bd0b61ec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421194961,
-    "wof:lastmodified":1690930232,
+    "wof:lastmodified":1695886598,
     "wof:name":"Pimienta",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/194/963/421194963.geojson
+++ b/data/421/194/963/421194963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014931,
-    "geom:area_square_m":179092930.26826,
+    "geom:area_square_m":179092922.207692,
     "geom:bbox":"-88.5298,13.963201,-88.376419,14.136439",
     "geom:latitude":14.056862,
     "geom:longitude":-88.464337,
@@ -117,12 +117,13 @@
         "qs_pg:id":62696,
         "wd:id":"Q2393748"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009826,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8866faa5e467ac7344babbbb9e9261ea",
+    "wof:geomhash":"dc063dba7157005e6ba813c70e57aa2b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421194963,
-    "wof:lastmodified":1690930230,
+    "wof:lastmodified":1695886596,
     "wof:name":"Piraera",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/197/119/421197119.geojson
+++ b/data/421/197/119/421197119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008295,
-    "geom:area_square_m":99062287.504392,
+    "geom:area_square_m":99062084.087427,
     "geom:bbox":"-88.050163,14.978804,-87.926804,15.086043",
     "geom:latitude":15.02516,
     "geom:longitude":-87.986274,
@@ -90,12 +90,13 @@
         "qs_pg:id":1311372,
         "wd:id":"Q1644762"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009903,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eeb66361fc3b82485924190b7f0899a7",
+    "wof:geomhash":"3f628369864bf46d9742fdb6793c7d1f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421197119,
-    "wof:lastmodified":1627522182,
+    "wof:lastmodified":1695886658,
     "wof:name":"San Francisco de Yojoa",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/198/881/421198881.geojson
+++ b/data/421/198/881/421198881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065487,
-    "geom:area_square_m":783896915.285687,
+    "geom:area_square_m":783897174.404865,
     "geom:bbox":"-87.419395,14.346916,-87.022194,14.704625",
     "geom:latitude":14.517969,
     "geom:longitude":-87.198851,
@@ -120,12 +120,13 @@
         "wd:id":"Q748590",
         "wk:page":"Cedros, Francisco Moraz\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009964,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5ae873f36f528edbc2c6920760324b82",
+    "wof:geomhash":"5937ef2aaccee33d2b76a5ca8e45457d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421198881,
-    "wof:lastmodified":1690930281,
+    "wof:lastmodified":1695886644,
     "wof:name":"Cedros",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/198/883/421198883.geojson
+++ b/data/421/198/883/421198883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044767,
-    "geom:area_square_m":533113650.249058,
+    "geom:area_square_m":533113004.63982,
     "geom:bbox":"-87.460663,15.437529,-87.266998,15.848055",
     "geom:latitude":15.619471,
     "geom:longitude":-87.3527,
@@ -88,12 +88,13 @@
         "hasc:id":"HN.AT.AR",
         "qs_pg:id":186307
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009964,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a9c6a9bab3ff3c8fb27f551a60dd8064",
+    "wof:geomhash":"c89246cf401be7619af387106460534e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":421198883,
-    "wof:lastmodified":1627522172,
+    "wof:lastmodified":1695886639,
     "wof:name":"Harizona",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/198/885/421198885.geojson
+++ b/data/421/198/885/421198885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004569,
-    "geom:area_square_m":54901338.026632,
+    "geom:area_square_m":54901285.546722,
     "geom:bbox":"-87.376686,13.609545,-87.298126,13.691101",
     "geom:latitude":13.651764,
     "geom:longitude":-87.337413,
@@ -113,12 +113,13 @@
         "wd:id":"Q2359263",
         "wk:page":"San Antonio de Flores"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009964,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e44eb1c46c55ac35e91676435a70531a",
+    "wof:geomhash":"8a318761decd4afe3781ad1acd7e634b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":421198885,
-    "wof:lastmodified":1627522181,
+    "wof:lastmodified":1695886657,
     "wof:name":"San Antonio de Flores",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/198/887/421198887.geojson
+++ b/data/421/198/887/421198887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043663,
-    "geom:area_square_m":521898962.642045,
+    "geom:area_square_m":521898003.49698,
     "geom:bbox":"-86.268852,14.725038,-85.981171,14.956049",
     "geom:latitude":14.839889,
     "geom:longitude":-86.138415,
@@ -91,12 +91,13 @@
         "qs_pg:id":186319,
         "wd:id":"Q2395000"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009964,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8d5cac7651da8c8f0d7c3260b50fce1a",
+    "wof:geomhash":"bd43bcad194bc955ffdf7fb1ef45a24d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421198887,
-    "wof:lastmodified":1627522182,
+    "wof:lastmodified":1695886659,
     "wof:name":"San Francisco de la Paz",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/198/889/421198889.geojson
+++ b/data/421/198/889/421198889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006619,
-    "geom:area_square_m":79165194.302489,
+    "geom:area_square_m":79165084.984418,
     "geom:bbox":"-88.087837,14.634612,-87.995918,14.765982",
     "geom:latitude":14.705597,
     "geom:longitude":-88.040797,
@@ -91,12 +91,13 @@
         "qs_pg:id":186320,
         "wd:id":"Q2296196"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009964,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9ba02e4706354777ec04562e8a795593",
+    "wof:geomhash":"dcb0b89e45292b27d6a638e6762439ea",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421198889,
-    "wof:lastmodified":1627522183,
+    "wof:lastmodified":1695886659,
     "wof:name":"San Jose de Comayagua",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/198/891/421198891.geojson
+++ b/data/421/198/891/421198891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01667,
-    "geom:area_square_m":199230874.219146,
+    "geom:area_square_m":199231042.988933,
     "geom:bbox":"-87.402374,14.751012,-87.209114,14.94094",
     "geom:latitude":14.86208,
     "geom:longitude":-87.300572,
@@ -121,12 +121,13 @@
         "wd:id":"Q2392225",
         "wk:page":"San Jos\u00e9 del Potrero"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009965,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1cddd7f1f3a657b868a7fe83125539b",
+    "wof:geomhash":"5ead871d110dea2595342891ec601e0a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421198891,
-    "wof:lastmodified":1690930283,
+    "wof:lastmodified":1695886645,
     "wof:name":"San Jose del Potrero",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/198/895/421198895.geojson
+++ b/data/421/198/895/421198895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00437,
-    "geom:area_square_m":52213885.768539,
+    "geom:area_square_m":52213765.457391,
     "geom:bbox":"-88.787773,14.891372,-88.639397,14.938006",
     "geom:latitude":14.913651,
     "geom:longitude":-88.714523,
@@ -172,12 +172,13 @@
         "wd:id":"Q2394109",
         "wk:page":"San Jos\u00e9, La Paz"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459009965,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"74827665090340cf1b9406d1512a55c9",
+    "wof:geomhash":"b5cdacd9048ea7d52fb43bfd036d723d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":421198895,
-    "wof:lastmodified":1690930281,
+    "wof:lastmodified":1695886689,
     "wof:name":"San Jose",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/199/873/421199873.geojson
+++ b/data/421/199/873/421199873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005045,
-    "geom:area_square_m":60363646.15598,
+    "geom:area_square_m":60363504.093631,
     "geom:bbox":"-88.885468,14.579326,-88.733536,14.650438",
     "geom:latitude":14.617553,
     "geom:longitude":-88.809079,
@@ -206,12 +206,13 @@
         "hasc:id":"HN.CP.SP",
         "qs_pg:id":505036
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010003,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b353aae404621e0349e132537f174e35",
+    "wof:geomhash":"cd69a223b62ed0d68f247a42d925b5b3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -221,7 +222,7 @@
         }
     ],
     "wof:id":421199873,
-    "wof:lastmodified":1636495865,
+    "wof:lastmodified":1695886692,
     "wof:name":"San Pedro",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/199/915/421199915.geojson
+++ b/data/421/199/915/421199915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056474,
-    "geom:area_square_m":674007213.94553,
+    "geom:area_square_m":674006802.410072,
     "geom:bbox":"-86.489822,14.98968,-86.258492,15.33434",
     "geom:latitude":15.162119,
     "geom:longitude":-86.374279,
@@ -117,12 +117,13 @@
         "qs_pg:id":511779,
         "wd:id":"Q2394928"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010005,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"666c12b0f448bce362e1215f390eaf21",
+    "wof:geomhash":"2b347f24f09efb95cf1cf31ad23e92df",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421199915,
-    "wof:lastmodified":1690930301,
+    "wof:lastmodified":1695886660,
     "wof:name":"Guata",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/199/961/421199961.geojson
+++ b/data/421/199/961/421199961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256935,
-    "geom:area_square_m":3067946738.402094,
+    "geom:area_square_m":3067945356.733329,
     "geom:bbox":"-85.697853,14.653333,-84.999802,15.432247",
     "geom:latitude":15.05797,
     "geom:longitude":-85.306851,
@@ -91,12 +91,13 @@
         "qs_pg:id":203656,
         "wd:id":"Q2248666"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010006,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0adf04c062c1c2a97cb8bdd6dd316a5b",
+    "wof:geomhash":"50e48d4235f030d3e4a5cd89c7ef9ef6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421199961,
-    "wof:lastmodified":1627522175,
+    "wof:lastmodified":1695886644,
     "wof:name":"Dulce nombre de Culmi",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/199/965/421199965.geojson
+++ b/data/421/199/965/421199965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009703,
-    "geom:area_square_m":116431438.60486,
+    "geom:area_square_m":116431360.383017,
     "geom:bbox":"-86.735184,13.911667,-86.556351,13.995675",
     "geom:latitude":13.95797,
     "geom:longitude":-86.648049,
@@ -136,12 +136,13 @@
         "wd:id":"Q2392501",
         "wk:page":"San Mat\u00edas, Honduras"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010006,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"517b300f58848a1ffc9ef4d3a0781043",
+    "wof:geomhash":"9c13d997b1776d5d64d19049082e5e14",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":421199965,
-    "wof:lastmodified":1690930300,
+    "wof:lastmodified":1695886693,
     "wof:name":"San Matias",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/199/967/421199967.geojson
+++ b/data/421/199/967/421199967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00625,
-    "geom:area_square_m":74664592.735027,
+    "geom:area_square_m":74664685.789976,
     "geom:bbox":"-88.851807,14.911066,-88.696663,14.978112",
     "geom:latitude":14.949742,
     "geom:longitude":-88.775225,
@@ -300,12 +300,13 @@
         "hasc:id":"HN.SB.TR",
         "qs_pg:id":203663
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010006,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8a3e2f2905b332cf5ae93549baec3e48",
+    "wof:geomhash":"98a002580b9bf07067e7bdc11f68ba6f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -315,7 +316,7 @@
         }
     ],
     "wof:id":421199967,
-    "wof:lastmodified":1636495865,
+    "wof:lastmodified":1695886693,
     "wof:name":"Trinidad",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/200/541/421200541.geojson
+++ b/data/421/200/541/421200541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003922,
-    "geom:area_square_m":46997747.918297,
+    "geom:area_square_m":46997747.918037,
     "geom:bbox":"-87.7537994385,14.2573385239,-87.6248550415,14.3104476929",
     "geom:latitude":14.282701,
     "geom:longitude":-87.681624,
@@ -112,12 +112,13 @@
         "hasc:id":"HN.LP.CN",
         "qs_pg:id":884747
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010029,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee814ead551f656d79fdf31207d7ca52",
+    "wof:geomhash":"f89cb36a76781deb3c7b723603250dd2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421200541,
-    "wof:lastmodified":1582319347,
+    "wof:lastmodified":1695886660,
     "wof:name":"Cane",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/200/543/421200543.geojson
+++ b/data/421/200/543/421200543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004346,
-    "geom:area_square_m":52187951.306223,
+    "geom:area_square_m":52188006.165144,
     "geom:bbox":"-87.746017,13.78389,-87.642845,13.851656",
     "geom:latitude":13.819059,
     "geom:longitude":-87.687685,
@@ -120,12 +120,13 @@
         "qs_pg:id":884749,
         "wd:id":"Q2394882"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010029,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bb229a282349f8963c4dfc1629332a60",
+    "wof:geomhash":"b910a3529dcfa5b564b78450d1c4e859",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421200543,
-    "wof:lastmodified":1690930301,
+    "wof:lastmodified":1695886660,
     "wof:name":"Caridad",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/200/721/421200721.geojson
+++ b/data/421/200/721/421200721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01033,
-    "geom:area_square_m":123508855.117977,
+    "geom:area_square_m":123509017.928873,
     "geom:bbox":"-87.516891,14.719354,-87.365654,14.833016",
     "geom:latitude":14.770984,
     "geom:longitude":-87.45359,
@@ -163,12 +163,13 @@
         "wd:id":"Q1643719",
         "wk:page":"San Luis, Comayagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010036,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9321cc1896c91c8f28fc0ac49d24c14b",
+    "wof:geomhash":"f4719dd72c36802cf5c57e6be3474831",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":421200721,
-    "wof:lastmodified":1690930303,
+    "wof:lastmodified":1695886693,
     "wof:name":"San Luis",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/200/723/421200723.geojson
+++ b/data/421/200/723/421200723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006005,
-    "geom:area_square_m":72257131.552663,
+    "geom:area_square_m":72257132.261996,
     "geom:bbox":"-87.141991,13.235726,-87.054588,13.374431",
     "geom:latitude":13.305287,
     "geom:longitude":-87.097421,
@@ -91,12 +91,13 @@
         "qs_pg:id":892475,
         "wd:id":"Q2358738"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010036,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"12f45403b480b09f0418bf1c84031811",
+    "wof:geomhash":"583e41db28fff22ebd2a77a48198a6fd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":421200723,
-    "wof:lastmodified":1627522185,
+    "wof:lastmodified":1695886663,
     "wof:name":"Sta. Ana de Yusguare",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/201/043/421201043.geojson
+++ b/data/421/201/043/421201043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047581,
-    "geom:area_square_m":567138796.926906,
+    "geom:area_square_m":567139078.051297,
     "geom:bbox":"-87.805611,15.199949,-87.598297,15.705886",
     "geom:latitude":15.432628,
     "geom:longitude":-87.698623,
@@ -126,12 +126,13 @@
         "qs_pg:id":209957,
         "wd:id":"Q2302837"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010049,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe9feff67daabf7f42fbe0a6b2eb6917",
+    "wof:geomhash":"ed2b2f14fb4ebda8c0ed94415585096c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421201043,
-    "wof:lastmodified":1690930305,
+    "wof:lastmodified":1695886661,
     "wof:name":"El Negrito",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/201/045/421201045.geojson
+++ b/data/421/201/045/421201045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033306,
-    "geom:area_square_m":397601615.047291,
+    "geom:area_square_m":397601711.010586,
     "geom:bbox":"-88.585838,15.001475,-88.363708,15.23747",
     "geom:latitude":15.109216,
     "geom:longitude":-88.477403,
@@ -203,12 +203,13 @@
         "hasc:id":"HN.SB.SL",
         "qs_pg:id":209958
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010050,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee28f3f4f48d155ef0117a79e942453b",
+    "wof:geomhash":"5ac3e2c2b68c821dd8a9e110b7507b88",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -218,7 +219,7 @@
         }
     ],
     "wof:id":421201045,
-    "wof:lastmodified":1636495866,
+    "wof:lastmodified":1695886693,
     "wof:name":"San Luis",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/201/047/421201047.geojson
+++ b/data/421/201/047/421201047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006596,
-    "geom:area_square_m":79145430.79607,
+    "geom:area_square_m":79145509.926591,
     "geom:bbox":"-87.126724,13.937597,-87.013199,14.03727",
     "geom:latitude":13.985465,
     "geom:longitude":-87.071355,
@@ -121,12 +121,13 @@
         "wd:id":"Q2137406",
         "wk:page":"Tatumbla"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010050,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"def8d014e884f041943cfefa47ee046d",
+    "wof:geomhash":"c8bd018de6c115301dbc5d96727e7860",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421201047,
-    "wof:lastmodified":1690930303,
+    "wof:lastmodified":1695886660,
     "wof:name":"Tatumbla",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/202/499/421202499.geojson
+++ b/data/421/202/499/421202499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00631,
-    "geom:area_square_m":75426173.407642,
+    "geom:area_square_m":75426130.726234,
     "geom:bbox":"-88.774101,14.762319,-88.652504,14.858045",
     "geom:latitude":14.812395,
     "geom:longitude":-88.708134,
@@ -94,12 +94,13 @@
         "qs_pg:id":223174,
         "wd:id":"Q2657178"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010120,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2f38833bab02fce12ab6fe3d867e9656",
+    "wof:geomhash":"b108edcb5995938d0650897a1bd65fb4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421202499,
-    "wof:lastmodified":1627522183,
+    "wof:lastmodified":1695886659,
     "wof:name":"San Juan de Opoa",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/202/501/421202501.geojson
+++ b/data/421/202/501/421202501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031872,
-    "geom:area_square_m":381891374.829566,
+    "geom:area_square_m":381891472.365399,
     "geom:bbox":"-87.116112,14.219359,-86.827232,14.40097",
     "geom:latitude":14.301487,
     "geom:longitude":-86.965719,
@@ -97,12 +97,13 @@
         "qs_pg:id":223181,
         "wd:id":"Q1018684"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010120,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2ec7a45a979fd2e0a18d761d66c2e0db",
+    "wof:geomhash":"ab44d3c30c6e0231f033f26f186556fd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":421202501,
-    "wof:lastmodified":1690930250,
+    "wof:lastmodified":1695886659,
     "wof:name":"San Juan de Flores",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/202/525/421202525.geojson
+++ b/data/421/202/525/421202525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003539,
-    "geom:area_square_m":42041487.910622,
+    "geom:area_square_m":42041481.694265,
     "geom:bbox":"-86.990547,16.05488,-86.871384,16.123806",
     "geom:latitude":16.097804,
     "geom:longitude":-86.93237,
@@ -155,12 +155,13 @@
         "qs_pg:id":224067,
         "wd:id":"Q1572113"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010121,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5e3b2b2c5a6318d70bde4026d711104e",
+    "wof:geomhash":"e305eb71501eb09517624531c8c077b9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421202525,
-    "wof:lastmodified":1690930251,
+    "wof:lastmodified":1695886612,
     "wof:name":"Utila",
     "wof:parent_id":85671869,
     "wof:placetype":"county",

--- a/data/421/203/399/421203399.geojson
+++ b/data/421/203/399/421203399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011585,
-    "geom:area_square_m":138442380.07916,
+    "geom:area_square_m":138442228.770311,
     "geom:bbox":"-86.782341,14.837078,-86.622856,14.972008",
     "geom:latitude":14.893878,
     "geom:longitude":-86.692372,
@@ -118,12 +118,13 @@
         "wd:id":"Q2394210",
         "wk:page":"El Rosario, Olancho"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010150,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe7a99439a1addca535cb7a4f8238ac5",
+    "wof:geomhash":"ca28bba2376fb87b6b3dd0fed53ced58",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421203399,
-    "wof:lastmodified":1690930243,
+    "wof:lastmodified":1695886608,
     "wof:name":"El Rosario",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/203/401/421203401.geojson
+++ b/data/421/203/401/421203401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032674,
-    "geom:area_square_m":390852200.518805,
+    "geom:area_square_m":390851986.338068,
     "geom:bbox":"-87.543938,14.523993,-87.254257,14.782177",
     "geom:latitude":14.670133,
     "geom:longitude":-87.405681,
@@ -120,12 +120,13 @@
         "qs_pg:id":62653,
         "wd:id":"Q2361049"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"88848d6fd9b76edd1ea30f48b88551b7",
+    "wof:geomhash":"a9103230ed5945ad3e084231137ce64b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421203401,
-    "wof:lastmodified":1690930246,
+    "wof:lastmodified":1695886610,
     "wof:name":"Esquias",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/203/403/421203403.geojson
+++ b/data/421/203/403/421203403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015974,
-    "geom:area_square_m":191994242.788263,
+    "geom:area_square_m":191994306.383805,
     "geom:bbox":"-87.793114,13.487191,-87.636375,13.694826",
     "geom:latitude":13.593753,
     "geom:longitude":-87.712639,
@@ -132,12 +132,13 @@
         "qs_pg:id":62655,
         "wd:id":"Q606540"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"30b71e3d3804f635f065afd135b9632b",
+    "wof:geomhash":"32bf15459f9d621ba5dccd4e22f1ea7d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421203403,
-    "wof:lastmodified":1690930249,
+    "wof:lastmodified":1695886612,
     "wof:name":"Goascoran",
     "wof:parent_id":85671883,
     "wof:placetype":"county",

--- a/data/421/203/405/421203405.geojson
+++ b/data/421/203/405/421203405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005576,
-    "geom:area_square_m":66595005.478936,
+    "geom:area_square_m":66594743.508946,
     "geom:bbox":"-88.239983,14.970223,-88.118668,15.039021",
     "geom:latitude":15.004488,
     "geom:longitude":-88.184546,
@@ -101,12 +101,13 @@
         "hasc:id":"HN.SB.GU",
         "qs_pg:id":62656
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9f2e589b93f51f2a8839433f092fed92",
+    "wof:geomhash":"1b15d36abc16eed55f241fe733be3f8c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":421203405,
-    "wof:lastmodified":1627522176,
+    "wof:lastmodified":1695886647,
     "wof:name":"Gualala",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/421/203/407/421203407.geojson
+++ b/data/421/203/407/421203407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013502,
-    "geom:area_square_m":161332288.234489,
+    "geom:area_square_m":161332489.357728,
     "geom:bbox":"-86.364235,14.818617,-86.223228,14.995399",
     "geom:latitude":14.904849,
     "geom:longitude":-86.289155,
@@ -117,12 +117,13 @@
         "qs_pg:id":62657,
         "wd:id":"Q568891"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"06308b5e465249fe7b41f71a1e853aee",
+    "wof:geomhash":"754f0ddb89cfca86518e6ac13eb7c3d4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421203407,
-    "wof:lastmodified":1690930247,
+    "wof:lastmodified":1695886611,
     "wof:name":"Guarizama",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/203/409/421203409.geojson
+++ b/data/421/203/409/421203409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003372,
-    "geom:area_square_m":40464956.817548,
+    "geom:area_square_m":40464990.65235,
     "geom:bbox":"-88.401741,13.869775,-88.347603,13.972628",
     "geom:latitude":13.92389,
     "geom:longitude":-88.372006,
@@ -160,12 +160,13 @@
         "wd:id":"Q2393454",
         "wk:page":"Magdalena, Intibuc\u00e1"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7987a45f36162c18a0a077067dc16a3d",
+    "wof:geomhash":"0e37d359aa44e67e3106b80092a0b545",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":421203409,
-    "wof:lastmodified":1690930246,
+    "wof:lastmodified":1695886671,
     "wof:name":"Magdalena",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/203/413/421203413.geojson
+++ b/data/421/203/413/421203413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031276,
-    "geom:area_square_m":373364548.457752,
+    "geom:area_square_m":373364309.221337,
     "geom:bbox":"-86.991455,14.983027,-86.757545,15.291144",
     "geom:latitude":15.106982,
     "geom:longitude":-86.847416,
@@ -117,12 +117,13 @@
         "qs_pg:id":62684,
         "wd:id":"Q2215530"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"22b595423849ee8db8a1af7df4d806b8",
+    "wof:geomhash":"d879c2d849bbe7df9d17b3dd413c7b37",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421203413,
-    "wof:lastmodified":1690930244,
+    "wof:lastmodified":1695886609,
     "wof:name":"Mangulile",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/421/203/415/421203415.geojson
+++ b/data/421/203/415/421203415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006296,
-    "geom:area_square_m":75571334.010682,
+    "geom:area_square_m":75571394.950611,
     "geom:bbox":"-87.769913,13.841446,-87.667969,13.939208",
     "geom:latitude":13.893242,
     "geom:longitude":-87.716986,
@@ -133,12 +133,13 @@
         "wd:id":"Q2132360",
         "wk:page":"San Antonio del Norte"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c5c881e0529fe9da7ff7e65389a4470",
+    "wof:geomhash":"a0d3b010b22a0ce055e6c2fb26367eaa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421203415,
-    "wof:lastmodified":1690930245,
+    "wof:lastmodified":1695886609,
     "wof:name":"San Antonio del Norte",
     "wof:parent_id":85671901,
     "wof:placetype":"county",

--- a/data/421/203/417/421203417.geojson
+++ b/data/421/203/417/421203417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008944,
-    "geom:area_square_m":107103116.879494,
+    "geom:area_square_m":107103182.96788,
     "geom:bbox":"-89.079948,14.368733,-88.893028,14.47798",
     "geom:latitude":14.428393,
     "geom:longitude":-88.992326,
@@ -141,12 +141,13 @@
         "qs_pg:id":62711,
         "wd:id":"Q2394017"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"24885db57265406ce0e193ec48b3b929",
+    "wof:geomhash":"b50dbd0c145828dc76f10167a07158cb",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":421203417,
-    "wof:lastmodified":1690930248,
+    "wof:lastmodified":1695886671,
     "wof:name":"San Francisco",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/421/203/419/421203419.geojson
+++ b/data/421/203/419/421203419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011518,
-    "geom:area_square_m":138117887.141748,
+    "geom:area_square_m":138117925.523005,
     "geom:bbox":"-88.436325,14.044137,-88.316002,14.220606",
     "geom:latitude":14.131925,
     "geom:longitude":-88.369368,
@@ -642,12 +642,13 @@
         "qs_pg:id":62712,
         "wd:id":"Q62"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f10b595ab27b999cf24d4a5434eec20c",
+    "wof:geomhash":"5f6749c24538e968674bb89f6e8161c1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -657,7 +658,7 @@
         }
     ],
     "wof:id":421203419,
-    "wof:lastmodified":1690930247,
+    "wof:lastmodified":1695886671,
     "wof:name":"San Francisco",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/203/421/421203421.geojson
+++ b/data/421/203/421/421203421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006658,
-    "geom:area_square_m":79683773.83586,
+    "geom:area_square_m":79683555.738153,
     "geom:bbox":"-88.163345,14.503983,-88.062019,14.626904",
     "geom:latitude":14.568312,
     "geom:longitude":-88.120926,
@@ -115,12 +115,13 @@
         "wd:id":"Q1646042",
         "wk:page":"San Isidro, Intibuc\u00e1"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c9d4d571664ae66b842bb70ecc469a80",
+    "wof:geomhash":"50273d9537fc0c2bdd07fad8bb5306bd",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421203421,
-    "wof:lastmodified":1690930248,
+    "wof:lastmodified":1695886611,
     "wof:name":"San Isidro",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/421/203/423/421203423.geojson
+++ b/data/421/203/423/421203423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004904,
-    "geom:area_square_m":58782025.284695,
+    "geom:area_square_m":58782086.140535,
     "geom:bbox":"-88.826324,14.187961,-88.684151,14.281167",
     "geom:latitude":14.226034,
     "geom:longitude":-88.762007,
@@ -115,12 +115,13 @@
         "wd:id":"Q1645794",
         "wk:page":"Tambla"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d306842dd158deef95a1077eedfca2ad",
+    "wof:geomhash":"54eea854658e9d23cf9c085fc2e33cfc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421203423,
-    "wof:lastmodified":1690930245,
+    "wof:lastmodified":1695886611,
     "wof:name":"Tambla",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/421/203/425/421203425.geojson
+++ b/data/421/203/425/421203425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005668,
-    "geom:area_square_m":68107181.017454,
+    "geom:area_square_m":68107076.382849,
     "geom:bbox":"-87.003853,13.57646,-86.888741,13.69748",
     "geom:latitude":13.639656,
     "geom:longitude":-86.954544,
@@ -118,12 +118,13 @@
         "wd:id":"Q2067159",
         "wk:page":"Vado Ancho"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010151,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"550e38820d441743da56a9222f61d6c8",
+    "wof:geomhash":"92762b58fdfd1285b09ef49a407e3dda",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":421203425,
-    "wof:lastmodified":1690930244,
+    "wof:lastmodified":1695886609,
     "wof:name":"Vado Ancho",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/203/451/421203451.geojson
+++ b/data/421/203/451/421203451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023811,
-    "geom:area_square_m":283508205.778742,
+    "geom:area_square_m":283508159.692683,
     "geom:bbox":"-87.10833,15.51174,-86.95356,15.786308",
     "geom:latitude":15.653754,
     "geom:longitude":-87.028198,
@@ -148,12 +148,13 @@
         "wd:id":"Q2361014",
         "wk:page":"San Francisco, Atl\u00e1ntida"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010152,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cba9206a70b4dc363ee899f0e993b28c",
+    "wof:geomhash":"d63044c4bfdfe1a065bde4f27319c255",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":421203451,
-    "wof:lastmodified":1690930248,
+    "wof:lastmodified":1695886672,
     "wof:name":"San Francisco",
     "wof:parent_id":85671851,
     "wof:placetype":"county",

--- a/data/421/203/561/421203561.geojson
+++ b/data/421/203/561/421203561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.210887,
-    "geom:area_square_m":2529126349.778773,
+    "geom:area_square_m":2529126412.966413,
     "geom:bbox":"-86.685837,13.763007,-86.070953,14.36069",
     "geom:latitude":14.09645,
     "geom:longitude":-86.376722,
@@ -89,12 +89,13 @@
         "hasc:id":"HN.EP.DA",
         "qs_pg:id":233549
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010156,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa48008af1916bcfa996af3bf67f2efe",
+    "wof:geomhash":"5abe42643cbb48ca2672d6a9494aef36",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":421203561,
-    "wof:lastmodified":1627522175,
+    "wof:lastmodified":1695886645,
     "wof:name":"Danli",
     "wof:parent_id":85671929,
     "wof:placetype":"county",

--- a/data/421/203/999/421203999.geojson
+++ b/data/421/203/999/421203999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03028,
-    "geom:area_square_m":361791231.74732,
+    "geom:area_square_m":361791017.185842,
     "geom:bbox":"-89.228142,14.712849,-89.031265,15.094914",
     "geom:latitude":14.922705,
     "geom:longitude":-89.136461,
@@ -124,12 +124,13 @@
         "wd:id":"Q2191693",
         "wk:page":"Cop\u00e1n Ruinas"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010170,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9f698bfa159eb2ecdbd8917a2f22f8b8",
+    "wof:geomhash":"7336cfcfb8e07efc6a01ebfb8d16cb71",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421203999,
-    "wof:lastmodified":1690930244,
+    "wof:lastmodified":1695886608,
     "wof:name":"Copan Ruinas",
     "wof:parent_id":85671911,
     "wof:placetype":"county",

--- a/data/421/204/279/421204279.geojson
+++ b/data/421/204/279/421204279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009457,
-    "geom:area_square_m":112691159.589544,
+    "geom:area_square_m":112691159.589367,
     "geom:bbox":"-87.9639434814,15.4109010696,-87.798789978,15.5973243713",
     "geom:latitude":15.484475,
     "geom:longitude":-87.86931,
@@ -115,12 +115,13 @@
         "hasc:id":"HN.CR.LL",
         "qs_pg:id":238962
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010179,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0bc4b09b3476d5539019c5bad2c70789",
+    "wof:geomhash":"977021dc641b2ed51b0449c3c1d94dc3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":421204279,
-    "wof:lastmodified":1582319273,
+    "wof:lastmodified":1695886607,
     "wof:name":"La Lima",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/204/281/421204281.geojson
+++ b/data/421/204/281/421204281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008877,
-    "geom:area_square_m":106438733.588199,
+    "geom:area_square_m":106438660.855754,
     "geom:bbox":"-87.068321,14.097793,-86.907677,14.229639",
     "geom:latitude":14.15376,
     "geom:longitude":-87.009816,
@@ -94,12 +94,13 @@
         "qs_pg:id":238963,
         "wd:id":"Q2393072"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010179,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"06fef6f91976c3adf8351b2d737bc222",
+    "wof:geomhash":"14d7501ac0d016931f6d74321f7d68ad",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":421204281,
-    "wof:lastmodified":1627522187,
+    "wof:lastmodified":1695886667,
     "wof:name":"Valle de Angeles",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/204/589/421204589.geojson
+++ b/data/421/204/589/421204589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170115,
-    "geom:area_square_m":2027416167.973909,
+    "geom:area_square_m":2027416167.973051,
     "geom:bbox":"-87.1657180786,15.264509201,-86.2265777588,15.6042881012",
     "geom:latitude":15.457178,
     "geom:longitude":-86.659914,
@@ -121,12 +121,13 @@
         "hasc:id":"HN.YO.OL",
         "qs_pg:id":1310478
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010191,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a3949c6117e4d417e492ab6f434b97b1",
+    "wof:geomhash":"9ec03d2ea45851d585d3cb198c1b7491",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":421204589,
-    "wof:lastmodified":1582319272,
+    "wof:lastmodified":1695886605,
     "wof:name":"Olanchito",
     "wof:parent_id":85671879,
     "wof:placetype":"county",

--- a/data/421/205/113/421205113.geojson
+++ b/data/421/205/113/421205113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069983,
-    "geom:area_square_m":837896898.951676,
+    "geom:area_square_m":837896837.787659,
     "geom:bbox":"-87.89743,14.357095,-87.384727,14.596642",
     "geom:latitude":14.470829,
     "geom:longitude":-87.624214,
@@ -253,12 +253,13 @@
         "wd:id":"Q679169",
         "wk:page":"Comayagua"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010212,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a4524587a7657d845b327ba4620fe010",
+    "wof:geomhash":"79aea7bcf50d3e0eaaf1168906c86699",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -268,7 +269,7 @@
         }
     ],
     "wof:id":421205113,
-    "wof:lastmodified":1690930252,
+    "wof:lastmodified":1695886673,
     "wof:name":"Comayagua",
     "wof:parent_id":85671887,
     "wof:placetype":"county",

--- a/data/421/205/117/421205117.geojson
+++ b/data/421/205/117/421205117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032352,
-    "geom:area_square_m":384939540.641383,
+    "geom:area_square_m":384939540.641252,
     "geom:bbox":"-87.9696426392,15.5932178497,-87.7191314697,15.921585083",
     "geom:latitude":15.789704,
     "geom:longitude":-87.845988,
@@ -116,12 +116,13 @@
         "hasc:id":"HN.CR.PC",
         "qs_pg:id":1195520
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010212,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8e21100cdb799f5918242d7d8cbcb72c",
+    "wof:geomhash":"863dd927a1cf31bce02db25eebbed9e4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421205117,
-    "wof:lastmodified":1582319283,
+    "wof:lastmodified":1695886614,
     "wof:name":"Puerto Cortes",
     "wof:parent_id":85671893,
     "wof:placetype":"county",

--- a/data/421/205/119/421205119.geojson
+++ b/data/421/205/119/421205119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020161,
-    "geom:area_square_m":241962558.363193,
+    "geom:area_square_m":241962228.328698,
     "geom:bbox":"-87.450821,13.820636,-87.251099,14.027122",
     "geom:latitude":13.927708,
     "geom:longitude":-87.340993,
@@ -120,12 +120,13 @@
         "qs_pg:id":1195521,
         "wd:id":"Q925071"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010212,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0984b771893aefb86fb621106b6740d8",
+    "wof:geomhash":"8323a0e79fdd8a8c5e57ec7082b3beef",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421205119,
-    "wof:lastmodified":1690930251,
+    "wof:lastmodified":1695886613,
     "wof:name":"Ojojona",
     "wof:parent_id":85671863,
     "wof:placetype":"county",

--- a/data/421/205/245/421205245.geojson
+++ b/data/421/205/245/421205245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010459,
-    "geom:area_square_m":125752251.175177,
+    "geom:area_square_m":125752068.88615,
     "geom:bbox":"-87.21698,13.409571,-87.069275,13.5647",
     "geom:latitude":13.497522,
     "geom:longitude":-87.139631,
@@ -117,12 +117,13 @@
         "qs_pg:id":259849,
         "wd:id":"Q2361001"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010216,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"42ed0176c793f94eaa76fbd46d1aacca",
+    "wof:geomhash":"8c4a29d043d4ef5613a25e69a412f9cf",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421205245,
-    "wof:lastmodified":1690930251,
+    "wof:lastmodified":1695886614,
     "wof:name":"Orocuina",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/421/205/531/421205531.geojson
+++ b/data/421/205/531/421205531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026049,
-    "geom:area_square_m":311379745.687349,
+    "geom:area_square_m":311379557.063587,
     "geom:bbox":"-88.681099,14.72173,-88.504013,14.948006",
     "geom:latitude":14.826564,
     "geom:longitude":-88.595124,
@@ -114,12 +114,13 @@
         "qs_pg:id":263802,
         "wd:id":"Q777598"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1459010227,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d82ec3ec5bcac386ea4fdf2d39bd6633",
+    "wof:geomhash":"3487fb19b536ee7b29cbdb286972dde5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":421205531,
-    "wof:lastmodified":1690930252,
+    "wof:lastmodified":1695886616,
     "wof:name":"Lepaera",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/856/323/23/85632323.geojson
+++ b/data/856/323/23/85632323.geojson
@@ -1166,6 +1166,7 @@
         "hasc:id":"HN",
         "icao:code":"HR",
         "ioc:id":"HON",
+        "iso:code":"HN",
         "itu:id":"HND",
         "loc:id":"n79096785",
         "m49:code":"340",
@@ -1179,6 +1180,7 @@
         "wk:page":"Honduras",
         "wmo:id":"HO"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:country_alpha3":"HND",
     "wof:geom_alt":[
@@ -1202,7 +1204,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694639600,
+    "wof:lastmodified":1695881261,
     "wof:name":"Honduras",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/323/23/85632323.geojson
+++ b/data/856/323/23/85632323.geojson
@@ -1128,7 +1128,7 @@
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"naturalearth",
-    "src:population_year":"2019",
+    "src:population_date":"2019",
     "statoids:dial":"504",
     "statoids:ds":"",
     "statoids:fifa":"HON",
@@ -1202,7 +1202,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1694492147,
+    "wof:lastmodified":1694639600,
     "wof:name":"Honduras",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/323/23/85632323.geojson
+++ b/data/856/323/23/85632323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.421988,
-    "geom:area_square_m":112620818859.809982,
+    "geom:area_square_m":112620853843.085663,
     "geom:bbox":"-89.355961,12.984225,-82.389137,17.418722",
     "geom:latitude":14.82234,
     "geom:longitude":-86.615838,
@@ -14,6 +14,9 @@
     "iso:country":"HN",
     "itu:country_code":[
         "504"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "country"
     ],
     "label:eng_x_preferred_shortcode":[
         "HN"
@@ -1124,7 +1127,8 @@
         "whosonfirst"
     ],
     "src:lbl_centroid":"mapshaper",
-    "src:population":"wk",
+    "src:population":"naturalearth",
+    "src:population_year":"2019",
     "statoids:dial":"504",
     "statoids:ds":"",
     "statoids:fifa":"HON",
@@ -1184,7 +1188,7 @@
         "quattroshapes",
         "whosonfirst-interior"
     ],
-    "wof:geomhash":"1a87bd0cc5d7c0b8f8c09d093b0c29ee",
+    "wof:geomhash":"f0bd9468777ea80bee038e73faa2da8c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -1198,12 +1202,12 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930187,
+    "wof:lastmodified":1694492147,
     "wof:name":"Honduras",
     "wof:parent_id":102191575,
     "wof:placetype":"country",
-    "wof:population":8097688,
-    "wof:population_rank":13,
+    "wof:population":9746117,
+    "wof:population_rank":18,
     "wof:repo":"whosonfirst-data-admin-hn",
     "wof:shortcode":"HN",
     "wof:superseded_by":[],

--- a/data/856/718/51/85671851.geojson
+++ b/data/856/718/51/85671851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.368,
-    "geom:area_square_m":4381385991.536224,
+    "geom:area_square_m":4381385825.023829,
     "geom:bbox":"-87.80204,15.420625,-86.362015,15.928492",
     "geom:latitude":15.664172,
     "geom:longitude":-87.135032,
@@ -321,17 +321,19 @@
         "gn:id":3615027,
         "gp:id":2345623,
         "hasc:id":"HN.AT",
+        "iso:code":"HN-AT",
         "iso:id":"HN-AT",
         "qs_pg:id":235599,
         "unlc:id":"HN-AT",
         "wd:id":"Q622619",
         "wk:page":"Atl\u00e1ntida Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2174bed8c7d7cc097f4a286a3725595e",
+    "wof:geomhash":"a3e65c6a35638cf947daa16e7fd8e2e5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -346,7 +348,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930200,
+    "wof:lastmodified":1695884346,
     "wof:name":"Atl\u00e1ntida",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/57/85671857.geojson
+++ b/data/856/718/57/85671857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.697785,
-    "geom:area_square_m":8308585752.500744,
+    "geom:area_square_m":8308584018.697145,
     "geom:bbox":"-86.458771,15.071033,-84.999565,16.028637",
     "geom:latitude":15.644101,
     "geom:longitude":-85.608482,
@@ -308,17 +308,19 @@
         "gn:id":3613358,
         "gp:id":2345625,
         "hasc:id":"HN.CL",
+        "iso:code":"HN-CL",
         "iso:id":"HN-CL",
         "qs_pg:id":219562,
         "unlc:id":"HN-CL",
         "wd:id":"Q867117",
         "wk:page":"Col\u00f3n Department (Honduras)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9a9d913c50bfd2e54133befde3d02191",
+    "wof:geomhash":"f43fa5e722764f647f063465d07f1367",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930198,
+    "wof:lastmodified":1695884342,
     "wof:name":"Col\u00f3n",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/63/85671863.geojson
+++ b/data/856/718/63/85671863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.71936,
-    "geom:area_square_m":8619676068.331408,
+    "geom:area_square_m":8619675937.061741,
     "geom:bbox":"-87.650055,13.653211,-86.710648,15.033292",
     "geom:latitude":14.289136,
     "geom:longitude":-87.17809,
@@ -318,17 +318,19 @@
         "gn:id":3609672,
         "gp:id":2345630,
         "hasc:id":"HN.FM",
+        "iso:code":"HN-FM",
         "iso:id":"HN-FM",
         "qs_pg:id":1311142,
         "unlc:id":"HN-FM",
         "wd:id":"Q867126",
         "wk:page":"Francisco Moraz\u00e1n Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f70e2c08466ae7c68f65f26beb17a694",
+    "wof:geomhash":"34ee51e3a723b8c5b3ccbac738b9ac6f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930211,
+    "wof:lastmodified":1695884350,
     "wof:name":"Francisco Moraz\u00e1n",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/67/85671867.geojson
+++ b/data/856/718/67/85671867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.334027,
-    "geom:area_square_m":15916616170.115974,
+    "geom:area_square_m":15916617632.662457,
     "geom:bbox":"-85.000069,14.615577,-83.149658,15.98161",
     "geom:latitude":15.221084,
     "geom:longitude":-84.362304,
@@ -304,17 +304,19 @@
         "gn:id":3609583,
         "gp:id":2345631,
         "hasc:id":"HN.GD",
+        "iso:code":"HN-GD",
         "iso:id":"HN-GD",
         "qs_pg:id":1311145,
         "unlc:id":"HN-GD",
         "wd:id":"Q867112",
         "wk:page":"Gracias a Dios Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"82be1f22d4c9d63809052a9e493e77ce",
+    "wof:geomhash":"75763c32d77dd949517fb7cf185b8d1c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930203,
+    "wof:lastmodified":1695884819,
     "wof:name":"Gracias a Dios",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/69/85671869.geojson
+++ b/data/856/718/69/85671869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019437,
-    "geom:area_square_m":230630832.992401,
+    "geom:area_square_m":230630832.991598,
     "geom:bbox":"-86.9905471802,15.9449996948,-85.8160018921,16.5167942047",
     "geom:latitude":16.340679,
     "geom:longitude":-86.381834,
@@ -287,17 +287,19 @@
         "gn:id":3608814,
         "gp:id":2345633,
         "hasc:id":"HN.IB",
+        "iso:code":"HN-IB",
         "iso:id":"HN-IB",
         "qs_pg:id":1311144,
         "unlc:id":"HN-IB",
         "wd:id":"Q751725",
         "wk:page":"Bay Islands Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f922f6f1372548e0cda1efc40a1fb4a2",
+    "wof:geomhash":"df07dd8df2cbacde4f3e0292f1dce5d2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1582319202,
+    "wof:lastmodified":1695884343,
     "wof:name":"Islas de la Bah\u00eda",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/718/77/85671877.geojson
+++ b/data/856/718/77/85671877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.019285,
-    "geom:area_square_m":24136267638.514202,
+    "geom:area_square_m":24136267180.803139,
     "geom:bbox":"-86.991455,14.045672,-84.999802,15.59628",
     "geom:latitude":14.833941,
     "geom:longitude":-85.927139,
@@ -304,17 +304,19 @@
         "gn:id":3604249,
         "gp:id":2345637,
         "hasc:id":"HN.OL",
+        "iso:code":"HN-OL",
         "iso:id":"HN-OL",
         "qs_pg:id":242273,
         "unlc:id":"HN-OL",
         "wd:id":"Q867089",
         "wk:page":"Olancho Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8768ad48c67d9c9c393a0f7fd1e6a65f",
+    "wof:geomhash":"48dc4932c1ef7673fc379f5f88fc9c81",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930220,
+    "wof:lastmodified":1695884832,
     "wof:name":"Olancho",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/79/85671879.geojson
+++ b/data/856/718/79/85671879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.655767,
-    "geom:area_square_m":7821025136.643897,
+    "geom:area_square_m":7821025956.741776,
     "geom:bbox":"-87.93866,14.875575,-86.226578,15.725393",
     "geom:latitude":15.306284,
     "geom:longitude":-87.20201,
@@ -301,17 +301,19 @@
         "gn:id":3600193,
         "gp:id":2345640,
         "hasc:id":"HN.YO",
+        "iso:code":"HN-YO",
         "iso:id":"HN-YO",
         "qs_pg:id":318504,
         "unlc:id":"HN-YO",
         "wd:id":"Q1123380",
         "wk:page":"Yoro Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bcdfce2a81b633112e6980ddd22cd851",
+    "wof:geomhash":"c75f5581ab3ae186feba784bf6dcca75",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930213,
+    "wof:lastmodified":1695884826,
     "wof:name":"Yoro",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/83/85671883.geojson
+++ b/data/856/718/83/85671883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135223,
-    "geom:area_square_m":1625565329.685973,
+    "geom:area_square_m":1625565306.101901,
     "geom:bbox":"-87.820702,13.248306,-87.340858,13.851656",
     "geom:latitude":13.542795,
     "geom:longitude":-87.590447,
@@ -304,17 +304,19 @@
         "gn:id":3600456,
         "gp:id":2345639,
         "hasc:id":"HN.VA",
+        "iso:code":"HN-VA",
         "iso:id":"HN-VA",
         "qs_pg:id":890075,
         "unlc:id":"HN-VA",
         "wd:id":"Q867097",
         "wk:page":"Valle Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7903824412d8d726070f9fb95d859d74",
+    "wof:geomhash":"c20dfd8d1d695d4480cec5652af4ee8a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930216,
+    "wof:lastmodified":1695884828,
     "wof:name":"Valle",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/87/85671887.geojson
+++ b/data/856/718/87/85671887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.430793,
-    "geom:area_square_m":5154216536.627023,
+    "geom:area_square_m":5154216320.745576,
     "geom:bbox":"-88.087837,14.047388,-87.209114,15.056875",
     "geom:latitude":14.624546,
     "geom:longitude":-87.633505,
@@ -271,17 +271,19 @@
         "gn:id":3613319,
         "gp:id":2345626,
         "hasc:id":"HN.CM",
+        "iso:code":"HN-CM",
         "iso:id":"HN-CM",
         "qs_pg:id":890073,
         "unlc:id":"HN-CM",
         "wd:id":"Q823443",
         "wk:page":"Comayagua Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bf9c26e70cbd065a27adec95a743b8eb",
+    "wof:geomhash":"8423acff5b483f5894bfdc09cbb619b5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -296,7 +298,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930208,
+    "wof:lastmodified":1695884824,
     "wof:name":"Comayagua",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/93/85671893.geojson
+++ b/data/856/718/93/85671893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.33246,
-    "geom:area_square_m":3963167921.659715,
+    "geom:area_square_m":3963169191.907177,
     "geom:bbox":"-88.472916,14.799693,-87.719131,15.921585",
     "geom:latitude":15.406134,
     "geom:longitude":-87.99324,
@@ -317,17 +317,19 @@
         "gn:id":3613140,
         "gp:id":2345628,
         "hasc:id":"HN.CR",
+        "iso:code":"HN-CR",
         "iso:id":"HN-CR",
         "qs_pg:id":890074,
         "unlc:id":"HN-CR",
         "wd:id":"Q767244",
         "wk:page":"Cort\u00e9s Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b2b982b35f27ddff9e1b023624d6676e",
+    "wof:geomhash":"50af5888bfd2900cc647040936a49c87",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -342,7 +344,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930206,
+    "wof:lastmodified":1695884348,
     "wof:name":"Cort\u00e9s",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/718/99/85671899.geojson
+++ b/data/856/718/99/85671899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.262068,
-    "geom:area_square_m":3139659312.656267,
+    "geom:area_square_m":3139659306.024448,
     "geom:bbox":"-88.511375,13.849,-87.847618,14.662828",
     "geom:latitude":14.33103,
     "geom:longitude":-88.210722,
@@ -302,17 +302,19 @@
         "gn:id":3608833,
         "gp:id":2345632,
         "hasc:id":"HN.IN",
+        "iso:code":"HN-IN",
         "iso:id":"HN-IN",
         "qs_pg:id":1311143,
         "unlc:id":"HN-IN",
         "wd:id":"Q262125",
         "wk:page":"Intibuc\u00e1 Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"451c58ecec8fe5c753486a543ee3557e",
+    "wof:geomhash":"e69209e2722d0eb26f9c5177b49a5704",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930210,
+    "wof:lastmodified":1695884349,
     "wof:name":"Intibuc\u00e1",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/01/85671901.geojson
+++ b/data/856/719/01/85671901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.212259,
-    "geom:area_square_m":2545491134.44794,
+    "geom:area_square_m":2545491268.98125,
     "geom:bbox":"-88.236511,13.830267,-87.591293,14.426847",
     "geom:latitude":14.104912,
     "geom:longitude":-87.881358,
@@ -313,17 +313,19 @@
         "gn:id":3607251,
         "gp:id":2345634,
         "hasc:id":"HN.LP",
+        "iso:code":"HN-LP",
         "iso:id":"HN-LP",
         "qs_pg:id":388549,
         "unlc:id":"HN-LP",
         "wd:id":"Q866886",
         "wk:page":"La Paz Department (Honduras)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57c27f0df25ba7698b9dab10767aa323",
+    "wof:geomhash":"a9408736a7e5bb6249303dc32b1dbec0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930193,
+    "wof:lastmodified":1695884814,
     "wof:name":"La Paz",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/05/85671905.geojson
+++ b/data/856/719/05/85671905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.424458,
-    "geom:area_square_m":5067342450.183638,
+    "geom:area_square_m":5067341471.342893,
     "geom:bbox":"-88.75824,14.642249,-87.98111,15.546744",
     "geom:latitude":15.0962,
     "geom:longitude":-88.348881,
@@ -318,17 +318,19 @@
         "gn:id":3601689,
         "gp:id":2345638,
         "hasc:id":"HN.SB",
+        "iso:code":"HN-SB",
         "iso:id":"HN-SB",
         "qs_pg:id":507449,
         "unlc:id":"HN-SB",
         "wd:id":"Q591139",
         "wk:page":"Santa B\u00e1rbara Department, Honduras"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"07325e85db6adc6185923c71d3bc9a75",
+    "wof:geomhash":"64514ef7be4f65e756e0e0d2a3c03288",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930187,
+    "wof:lastmodified":1695884339,
     "wof:name":"Santa B\u00e1rbara",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/11/85671911.geojson
+++ b/data/856/719/11/85671911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.272054,
-    "geom:area_square_m":3250770278.259577,
+    "geom:area_square_m":3250769899.047302,
     "geom:bbox":"-89.228142,14.496684,-88.63678,15.29493",
     "geom:latitude":14.906912,
     "geom:longitude":-88.899618,
@@ -311,17 +311,19 @@
         "gn:id":3613229,
         "gp:id":2345627,
         "hasc:id":"HN.CP",
+        "iso:code":"HN-CP",
         "iso:id":"HN-CP",
         "qs_pg:id":1285249,
         "unlc:id":"HN-CP",
         "wd:id":"Q843984",
         "wk:page":"Cop\u00e1n Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f63cc56f49067bf677ede62138ffe81c",
+    "wof:geomhash":"8f20e8323049f1896b4d5de2e3b2804e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930188,
+    "wof:lastmodified":1695884339,
     "wof:name":"Cop\u00e1n",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/15/85671915.geojson
+++ b/data/856/719/15/85671915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.359212,
-    "geom:area_square_m":4301953756.322783,
+    "geom:area_square_m":4301953632.749185,
     "geom:bbox":"-88.981537,13.963201,-88.316002,14.948006",
     "geom:latitude":14.40998,
     "geom:longitude":-88.593103,
@@ -298,17 +298,19 @@
         "gn:id":3606066,
         "gp:id":2345635,
         "hasc:id":"HN.LE",
+        "iso:code":"HN-LE",
         "iso:id":"HN-LE",
         "qs_pg:id":1112291,
         "unlc:id":"HN-LE",
         "wd:id":"Q744138",
         "wk:page":"Lempira Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d15d898ae3743b23dd825adb16af0c2",
+    "wof:geomhash":"0e73b12cc6f27485a41f2423016c9897",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930197,
+    "wof:lastmodified":1695884818,
     "wof:name":"Lempira",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/19/85671919.geojson
+++ b/data/856/719/19/85671919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137119,
-    "geom:area_square_m":1641559881.600759,
+    "geom:area_square_m":1641560019.990918,
     "geom:bbox":"-89.356644,14.225257,-88.714531,14.726662",
     "geom:latitude":14.490826,
     "geom:longitude":-89.042377,
@@ -301,17 +301,19 @@
         "gn:id":3604318,
         "gp:id":2345636,
         "hasc:id":"HN.OC",
+        "iso:code":"HN-OC",
         "iso:id":"HN-OC",
         "qs_pg:id":908262,
         "unlc:id":"HN-OC",
         "wd:id":"Q867084",
         "wk:page":"Ocotepeque Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2cee0dbb4e47075bc19b14296b2afa8b",
+    "wof:geomhash":"92e467e8c770ed4e174a3ee45c946ff1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930192,
+    "wof:lastmodified":1695884812,
     "wof:name":"Ocotepeque",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/23/85671923.geojson
+++ b/data/856/719/23/85671923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.367212,
-    "geom:area_square_m":4417936773.957323,
+    "geom:area_square_m":4417936394.147366,
     "geom:bbox":"-87.516449,12.983047,-86.703629,13.759345",
     "geom:latitude":13.349781,
     "geom:longitude":-87.116432,
@@ -307,17 +307,19 @@
         "gn:id":3613527,
         "gp:id":2345624,
         "hasc:id":"HN.CH",
+        "iso:code":"HN-CH",
         "iso:id":"HN-CH",
         "qs_pg:id":219561,
         "unlc:id":"HN-CH",
         "wd:id":"Q899272",
         "wk:page":"Choluteca Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"40de9ba1076c6cc824a53c8bc476c92c",
+    "wof:geomhash":"34976ae4157c8bf150632893cbb9305e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -332,7 +334,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930195,
+    "wof:lastmodified":1695884815,
     "wof:name":"Choluteca",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/856/719/29/85671929.geojson
+++ b/data/856/719/29/85671929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.618229,
-    "geom:area_square_m":7416710132.112741,
+    "geom:area_square_m":7416710311.912468,
     "geom:bbox":"-87.224709,13.501615,-85.569672,14.422551",
     "geom:latitude":14.021689,
     "geom:longitude":-86.479505,
@@ -310,17 +310,19 @@
         "gn:id":3610942,
         "gp:id":2345629,
         "hasc:id":"HN.EP",
+        "iso:code":"HN-EP",
         "iso:id":"HN-EP",
         "qs_pg:id":1135067,
         "unlc:id":"HN-EP",
         "wd:id":"Q867108",
         "wk:page":"El Para\u00edso Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HN",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"77e914e7d527452455d566ca84835a8f",
+    "wof:geomhash":"1188c5a9ae0d3860bfdb8b55958ed652",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "spa"
     ],
-    "wof:lastmodified":1690930189,
+    "wof:lastmodified":1695884340,
     "wof:name":"El Para\u00edso",
     "wof:parent_id":85632323,
     "wof:placetype":"region",

--- a/data/890/414/563/890414563.geojson
+++ b/data/890/414/563/890414563.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008094,
-    "geom:area_square_m":96945339.332806,
+    "geom:area_square_m":96945319.312071,
     "geom:bbox":"-88.690811,14.335191,-88.52816,14.440048",
     "geom:latitude":14.387576,
     "geom:longitude":-88.600518,
@@ -82,12 +82,13 @@
         "wd:id":"Q922209",
         "wk:page":"San Marcos de Caiqu\u00edn"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469051053,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"30d7ef9426e555fbb405f4ed2c1d789a",
+    "wof:geomhash":"ab17530cc17e286c44f28f85288e4c71",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":890414563,
-    "wof:lastmodified":1627522184,
+    "wof:lastmodified":1695886661,
     "wof:name":"Caiquin",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/890/420/201/890420201.geojson
+++ b/data/890/420/201/890420201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020251,
-    "geom:area_square_m":242083347.8276,
+    "geom:area_square_m":242083286.993625,
     "geom:bbox":"-86.048981,14.629442,-85.909798,14.9359",
     "geom:latitude":14.818511,
     "geom:longitude":-85.962213,
@@ -103,12 +103,13 @@
         "wd:id":"Q305214",
         "wk:page":"Santa Maria del Real"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469051323,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"13d89e6907d40681306b7a53baf5f609",
+    "wof:geomhash":"79d616215709af86300217ca35efc005",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":890420201,
-    "wof:lastmodified":1690930355,
+    "wof:lastmodified":1695886697,
     "wof:name":"Santa Maria del Real",
     "wof:parent_id":85671877,
     "wof:placetype":"county",

--- a/data/890/420/205/890420205.geojson
+++ b/data/890/420/205/890420205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017549,
-    "geom:area_square_m":208748065.709122,
+    "geom:area_square_m":208748074.340983,
     "geom:bbox":"-86.208473,15.749769,-85.992966,15.905231",
     "geom:latitude":15.846698,
     "geom:longitude":-86.115607,
@@ -121,12 +121,13 @@
         "wd:id":"Q1958069",
         "wk:page":"Santa Fe"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469051323,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"47633517330b55f51a3c4ab74cb63c2f",
+    "wof:geomhash":"5e576463ff9f922f145ec634e2fac668",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":890420205,
-    "wof:lastmodified":1690930354,
+    "wof:lastmodified":1695886703,
     "wof:name":"Santa Fe",
     "wof:parent_id":85671857,
     "wof:placetype":"county",

--- a/data/890/420/215/890420215.geojson
+++ b/data/890/420/215/890420215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011949,
-    "geom:area_square_m":143271511.697933,
+    "geom:area_square_m":143271721.698195,
     "geom:bbox":"-88.329529,14.064939,-88.15432,14.183154",
     "geom:latitude":14.135956,
     "geom:longitude":-88.248349,
@@ -79,12 +79,13 @@
         "wd:id":"Q765638",
         "wk:page":"San Marco de Sierra"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469051324,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e81e9ec74fec17b7f5606755a9d2135f",
+    "wof:geomhash":"0bb9e63c986241a3f41674abdf78825a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":890420215,
-    "wof:lastmodified":1627522184,
+    "wof:lastmodified":1695886661,
     "wof:name":"San Marcos de Sierra",
     "wof:parent_id":85671899,
     "wof:placetype":"county",

--- a/data/890/420/217/890420217.geojson
+++ b/data/890/420/217/890420217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003596,
-    "geom:area_square_m":43121593.473294,
+    "geom:area_square_m":43121519.192163,
     "geom:bbox":"-88.82933,14.102782,-88.754051,14.192805",
     "geom:latitude":14.150476,
     "geom:longitude":-88.784614,
@@ -102,12 +102,13 @@
         "wd:id":"Q1646012",
         "wk:page":"San Juan Guarita"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469051324,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1e0af5be5f4ef1bd636ee2cdc56a6fcc",
+    "wof:geomhash":"757ce8b30034e4103bfe48fe36035fc0",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890420217,
-    "wof:lastmodified":1690930353,
+    "wof:lastmodified":1695886697,
     "wof:name":"San Juan Guarita",
     "wof:parent_id":85671915,
     "wof:placetype":"county",

--- a/data/890/420/221/890420221.geojson
+++ b/data/890/420/221/890420221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020302,
-    "geom:area_square_m":242402127.834143,
+    "geom:area_square_m":242402103.816818,
     "geom:bbox":"-88.413925,14.977423,-88.224548,15.170983",
     "geom:latitude":15.070867,
     "geom:longitude":-88.328106,
@@ -79,12 +79,13 @@
         "hasc:id":"HN.SB.SJ",
         "qs_pg:id":96038
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469051324,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3dbffac02eb03e05edc3be456294ab23",
+    "wof:geomhash":"2fb2ad621ec93940d8fac6694db3bd07",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":890420221,
-    "wof:lastmodified":1627522183,
+    "wof:lastmodified":1695886660,
     "wof:name":"San Jose de Colinas",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/890/421/511/890421511.geojson
+++ b/data/890/421/511/890421511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013998,
-    "geom:area_square_m":168505840.908284,
+    "geom:area_square_m":168505830.083002,
     "geom:bbox":"-87.039062,13.127125,-86.892921,13.31702",
     "geom:latitude":13.221407,
     "geom:longitude":-86.962037,
@@ -86,12 +86,13 @@
         "wd:id":"Q2358808",
         "wk:page":"Concepci\u00f3n de Mar\u00eda"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469051395,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dd2674a7ffff108fe33f3acba4692223",
+    "wof:geomhash":"1a2c0efa8f9ba960944df4d482d816c6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":890421511,
-    "wof:lastmodified":1627522174,
+    "wof:lastmodified":1695886642,
     "wof:name":"Concepcion de Maria",
     "wof:parent_id":85671923,
     "wof:placetype":"county",

--- a/data/890/429/335/890429335.geojson
+++ b/data/890/429/335/890429335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014643,
-    "geom:area_square_m":175362040.263171,
+    "geom:area_square_m":175362540.585559,
     "geom:bbox":"-89.355972,14.352986,-89.101837,14.485903",
     "geom:latitude":14.419094,
     "geom:longitude":-89.222847,
@@ -204,12 +204,13 @@
         "wd:id":"Q3307235",
         "wk:page":"Nueva Ocotepeque"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469051810,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"df2559b04a8f762743a18b60f108c7ad",
+    "wof:geomhash":"724efb7ec838bba3edbd246ce9769508",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -219,7 +220,7 @@
         }
     ],
     "wof:id":890429335,
-    "wof:lastmodified":1690930353,
+    "wof:lastmodified":1695886703,
     "wof:name":"Nueva Ocotepeque",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/890/429/347/890429347.geojson
+++ b/data/890/429/347/890429347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003076,
-    "geom:area_square_m":36800078.277519,
+    "geom:area_square_m":36800058.665434,
     "geom:bbox":"-89.103905,14.633452,-88.990982,14.693204",
     "geom:latitude":14.664971,
     "geom:longitude":-89.049036,
@@ -105,12 +105,13 @@
         "wd:id":"Q2023539",
         "wk:page":"La Encarnaci\u00f3n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469051811,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3c3051764d95ad98feca90822028c3f1",
+    "wof:geomhash":"300c4ebcc4b1857a258bedcaf0f2a7b8",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":890429347,
-    "wof:lastmodified":1690930352,
+    "wof:lastmodified":1695886696,
     "wof:name":"La Encarnacion",
     "wof:parent_id":85671919,
     "wof:placetype":"county",

--- a/data/890/455/339/890455339.geojson
+++ b/data/890/455/339/890455339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062396,
-    "geom:area_square_m":743787437.033026,
+    "geom:area_square_m":743787210.051684,
     "geom:bbox":"-88.534416,15.286146,-88.144547,15.546744",
     "geom:latitude":15.414094,
     "geom:longitude":-88.357204,
@@ -105,12 +105,13 @@
         "wd:id":"Q2394900",
         "wk:page":"Quimist\u00e1n"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469052943,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"86b8462dfd407cc92e0c0f6299e672ac",
+    "wof:geomhash":"e7961780453613e4cea044825347e42b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":890455339,
-    "wof:lastmodified":1690930350,
+    "wof:lastmodified":1695886696,
     "wof:name":"Quimistan",
     "wof:parent_id":85671905,
     "wof:placetype":"county",

--- a/data/890/455/353/890455353.geojson
+++ b/data/890/455/353/890455353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030398,
-    "geom:area_square_m":364479228.574318,
+    "geom:area_square_m":364479154.863331,
     "geom:bbox":"-86.987679,14.046991,-86.723557,14.292202",
     "geom:latitude":14.148213,
     "geom:longitude":-86.854029,
@@ -108,12 +108,13 @@
         "wd:id":"Q633411",
         "wk:page":"Morocel\u00ed"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"HN",
     "wof:created":1469052943,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1158ecd66d91b18d5f7099e40fec620",
+    "wof:geomhash":"78546699031a508cbf5ecc393bdf3d1f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":890455353,
-    "wof:lastmodified":1690930350,
+    "wof:lastmodified":1695886695,
     "wof:name":"Moroceli",
     "wof:parent_id":85671929,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.